### PR TITLE
Test for megaraid device symbols being :undefined

### DIFF
--- a/templates/smartd.conf
+++ b/templates/smartd.conf
@@ -9,8 +9,8 @@ DEFAULT -m <%= @mail_to %> -M <%= @warning_schedule %>
 <% megaraid_adapters = scope.lookupvar('::megaraid_adapters')
 megaraid_device = scope.lookupvar('::megaraid_virtual_drives')
 megaraid_drives = scope.lookupvar('::megaraid_physical_drives')
-megaraid_device = megaraid_device.split(/,/)[0]
-megaraid_drives = megaraid_drives.nil? ? [] : megaraid_drives.split(/,/)
+megaraid_device = megaraid_device == :undefined ? "" : megaraid_device.split(/,/)[0]
+megaraid_drives = megaraid_drives == :undefined ? [] : megaraid_drives.split(/,/)
 
 if megaraid_device and megaraid_device != '' and
      megaraid_adapters and megaraid_adapters.to_i > 0 -%>


### PR DESCRIPTION
When running without megaraid devices puppet throws an error about being unable
to split on :undefined:Symbol so we should test if its undefined and not attempt
the split
