### PR TITLE
merge class smartd $devices and $device_options -> $devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ Usage
       config_file        => '/etc/smartd.conf',
       devicescan         => true,
       devicescan_options => '-H -m admin@example.com',
-      devices            => [ '/dev/sg1', '/dev/sg2' ],
-      device_options     => { '/dev/sg1' => '-o on -S on -a', '/dev/sg2' => '-o on -S on -a' },
+      devices            => [
+        { device => '/dev/sg1', options => '-o on -S on -a' },
+        { device => '/dev/sg2', options => '-o on -S on -a' },
+      ],
       mail_to            => 'root',
       warning_schedule   => 'diminishing',
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,20 +62,12 @@
 #   defaults to: ''
 #
 # [*devices*]
-#   Array of Strings.
+#   Array of Hash.
 #
 #   Explicit list of raw block devices to check.  Eg.
-#     ['/dev/sda', '/dev/sdb']
+#     [{ device => '/dev/sda', options => '-I 194' }]
 #
 #   defaults to: []
-#
-# [*device_options*]
-#   Hash.
-#
-#   List of options to pass to a specific device.  Eg.
-#     { '/dev/sda' => '-H -l error -l selftest -t -I 194' }
-#
-#   defaults to: {}
 #
 # [*mail_to*]
 #   String.
@@ -110,7 +102,6 @@ class smartd (
   $devicescan         = $smartd::params::devicescan,
   $devicescan_options = $smartd::params::devicescan_options,
   $devices            = $smartd::params::devices,
-  $device_options     = $smartd::params::device_options,
   $mail_to            = $smartd::params::mail_to,
   $warning_schedule   = $smartd::params::warning_schedule,
 ) inherits smartd::params {
@@ -122,7 +113,6 @@ class smartd (
   validate_bool($devicescan)
   validate_string($devicescan_options)
   validate_array($devices)
-  validate_hash($device_options)
   validate_string($mail_to)
   validate_re($warning_schedule, '^daily$|^once$|^diminishing$',
     '$warning_schedule must be either daily, once, or diminishing.')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,6 @@ class smartd::params {
   $devicescan         = true
   $devicescan_options = undef
   $devices            = []
-  $device_options     = {}
   $mail_to            = 'root'
   $warning_schedule   = 'daily' # other choices: once, diminishing
 

--- a/spec/classes/smartd_spec.rb
+++ b/spec/classes/smartd_spec.rb
@@ -147,7 +147,7 @@ describe 'smartd', :type => :class do
       let(:params) {{ :devicescan_options => 'somevalue' }}
 
       it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain File[/etc/smartd.conf] with contents "DEVICESCAN somevalue"' do
+      it 'should contain file /etc/smartd.conf with contents ...' do
         verify_contents(subject, '/etc/smartd.conf', [
           'DEFAULT -m root -M daily',
           'DEVICESCAN somevalue',
@@ -155,11 +155,18 @@ describe 'smartd', :type => :class do
       end
     end
 
-    describe 'devices => [ /dev/sg1, /dev/sg2 ]' do
-      let(:params) {{ :devices => [ '/dev/sg1', '/dev/sg2', ] }}
+    describe 'devices without options' do
+      let(:params) do
+        {
+          'devices' => [
+            { 'device' => '/dev/sg1' },
+            { 'device' => '/dev/sg2' },
+          ],
+        }
+      end
 
       it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain File[/etc/smartd.conf] with contents "/dev/sg1\n/dev/sg2"' do
+      it 'should contain file /etc/smartd.conf with contents ...' do
         verify_contents(subject, '/etc/smartd.conf', [
           'DEFAULT -m root -M daily',
           '/dev/sg1',
@@ -168,15 +175,18 @@ describe 'smartd', :type => :class do
       end
     end
 
-    describe 'device_options => "{ /dev/sg1 => -o on -S on -a, /dev/sg2 => -o on -S on -a }"' do
-      let :params do {
-        :devices     => [ '/dev/sg1', '/dev/sg2', ],
-        :device_options => { '/dev/sg1' => '-o on -S on -a', '/dev/sg2' => '-o on -S on -a' }
-      }
+    describe 'devices with options"' do
+      let :params do
+        {
+          'devices' => [
+            { 'device' => '/dev/sg1', 'options' => '-o on -S on -a' },
+            { 'device' => '/dev/sg2', 'options' => '-o on -S on -a' },
+          ],
+        }
       end
 
       it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain File[/etc/smartd.conf] with contents "/dev/sg1 -o on -S on -a\n/dev/sg2 -o on -S on -a"' do
+      it 'should contain file /etc/smartd.conf with contents ...' do
         verify_contents(subject, '/etc/smartd.conf', [
           'DEFAULT -m root -M daily',
           '/dev/sg1 -o on -S on -a',
@@ -185,11 +195,40 @@ describe 'smartd', :type => :class do
       end
     end
 
+    describe 'devices with options"' do
+      let :params do
+        {
+          'devices' => [
+            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,0 -a -o on -S on' },
+            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,1 -a -o on -S on' },
+            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,2 -a -o on -S on' },
+            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,3 -a -o on -S on' },
+            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,4 -a -o on -S on' },
+            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,5 -a -o on -S on' },
+
+          ],
+        }
+      end
+
+      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+      it 'should contain file /etc/smartd.conf with contents ...' do
+        verify_contents(subject, '/etc/smartd.conf', [
+          'DEFAULT -m root -M daily',
+          '/dev/cciss/c0d0 -d cciss,0 -a -o on -S on',
+          '/dev/cciss/c0d0 -d cciss,1 -a -o on -S on',
+          '/dev/cciss/c0d0 -d cciss,2 -a -o on -S on',
+          '/dev/cciss/c0d0 -d cciss,3 -a -o on -S on',
+          '/dev/cciss/c0d0 -d cciss,4 -a -o on -S on',
+          '/dev/cciss/c0d0 -d cciss,5 -a -o on -S on',
+        ])
+      end
+    end
+
     describe 'mail_to => someguy@localdomain' do
       let(:params) {{ :mail_to => 'someguy@localdomain' }}
 
       it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain File[/etc/smartd.conf] with contents "DEFAULT -m someguy@localdomain -M daily"' do
+      it 'should contain file /etc/smartd.conf with contents ...' do
         verify_contents(subject, '/etc/smartd.conf', [
           'DEFAULT -m someguy@localdomain -M daily',
         ])
@@ -200,7 +239,7 @@ describe 'smartd', :type => :class do
       let(:params) {{ :warning_schedule => 'diminishing' }}
 
       it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain File[/etc/smartd.conf] with contents "DEFAULT -m root -M diminishing"' do
+      it 'should contain file /etc/smartd.conf with contents ...' do
         verify_contents(subject, '/etc/smartd.conf', [
           'DEFAULT -m root -M diminishing',
         ])
@@ -255,7 +294,7 @@ describe 'smartd', :type => :class do
       end
       let(:params) do
         {
-          :device_options => { 'megaraid' => '-I 194'},
+          :devices => [{ 'device' => 'megaraid', 'options' => '-I 194' }],
         }
       end
   

--- a/templates/smartd.conf
+++ b/templates/smartd.conf
@@ -1,8 +1,8 @@
 # Managed by Puppet -- do not edit!
 DEFAULT -m <%= @mail_to %> -M <%= @warning_schedule %>
-<% @devices.each do |device| -%>
-<%= device -%>
-<% if @device_options.has_key?(device) -%> <%= @device_options[device] %><% end %>
+<% @devices.each do |dev| -%>
+<%  next if dev['device'] == 'megaraid' -%>
+<%= dev['device'] %><% if dev.has_key?('options') -%><%= ' ' + dev['options'] %><% end %>
 <% end -%>
 <%
 # it doesn't matter which megaraid block device we use to poll as long as all
@@ -12,13 +12,17 @@ if @megaraid_virtual_drives and @megaraid_virtual_drives != ''
   megaraid_device = @megaraid_virtual_drives.split(/,/).sort[0]
 end
 
+# if there is an entry for megaraid device options fish it out
+megaraid_options = nil
+@devices.each { |dev| dev['device'] == 'megaraid' ? megaraid_options = dev['options'] : nil }
+
 if megaraid_device and megaraid_device != '' and
      @megaraid_adapters and @megaraid_adapters.to_i > 0
   @megaraid_physical_drives.split(/,/).sort.each do |drive| -%>
 <%= megaraid_device %> -d sat+megaraid,<%= drive.to_i -%>
-<% if @device_options.has_key?('megaraid') %> <%= @device_options['megaraid'] %><% end %>
+<% if megaraid_options %><%= ' ' + megaraid_options %><% end %>
 <% end -%>
 <% end -%>
 <% if @devicescan -%>
-DEVICESCAN<% if @devicescan_options %><%= " " + @devicescan_options %><% end %>
+DEVICESCAN<% if @devicescan_options %><%= ' ' + @devicescan_options %><% end %>
 <% end -%>


### PR DESCRIPTION
$devices is now accepts and Array of Hash.  This is to allow multiple
smartd.conf entires for the same blockdev as is typically required for probing
through to individual disks behind a block device presented by a RAID
controller.
