### PR TITLE
Fix $service_name in Debian distributions to use 'smartmontools'

### DIFF
--- a/spec/system/smartd_spec.rb
+++ b/spec/system/smartd_spec.rb
@@ -2,12 +2,9 @@ require 'spec_helper_system'
 
 describe 'smartd class' do
   case node.facts['osfamily']
-  when 'RedHat', 'SuSE'
+  when 'RedHat', 'Debian'
     package_name = 'smartmontools'
     service_name = 'smartd'
-  when 'Debian'
-    package_name = 'smartmontools'
-    service_name = 'smartmontools'
   end
 
   describe 'running puppet code' do


### PR DESCRIPTION
The service has been called `smartmontools` in Debian for a while but the module by default calls it `smartd`. 

See `/etc/init.d/smartmontools` in:
https://packages.debian.org/wheezy/amd64/smartmontools/filelist
https://packages.debian.org/sid/amd64/smartmontools/filelist
http://packages.ubuntu.com/lucid/amd64/smartmontools/filelist
http://packages.ubuntu.com/trusty/amd64/smartmontools/filelist
