### PR TITLE
Allow the service to start only after the package is installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,11 +169,12 @@ class smartd (
   # to be enabled, it also needs its own extra special config file.
   if $::osfamily == 'Debian' {
     shell_config { 'start_smartd':
-      ensure => $file_ensure,
-      file   => '/etc/default/smartmontools',
-      key    => 'start_smartd',
-      value  => 'yes',
-      before => Service[$service_name],
+      ensure  => $file_ensure,
+      file    => '/etc/default/smartmontools',
+      key     => 'start_smartd',
+      value   => 'yes',
+      before  => Service[$service_name],
+      require => Package[$package_name],
     }
   }
 


### PR DESCRIPTION
I was having an issue installing smartmontools on a Debian box, due to smartd.conf not being configured before the service was trying to start. Disabling smartd starting by setting `start_smartd=no` would work but `shell_config` overrides that setting before installing the package.

This PR ensures that the `shell_config` is called after the package is installed, but before the service is started. 
