### PR TITLE
Added debian support and working tests. Closes #32

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,6 @@
 #
 class smartd::params {
   $package_name       = 'smartmontools'
-  $service_name       = 'smartd'
   $service_ensure     = 'running'
   $devicescan         = true
   $devicescan_options = undef
@@ -33,9 +32,15 @@ class smartd::params {
   case $::osfamily {
     'FreeBSD': {
       $config_file = '/usr/local/etc/smartd.conf'
+      $service_name = 'smartd'
     }
-    'Debian', 'RedHat', 'SuSE': {
+    'RedHat', 'SuSE': {
       $config_file = '/etc/smartd.conf'
+      $service_name = 'smartd'
+    }
+    'Debian': {
+      $config_file = '/etc/smartd.conf'
+      $service_name = 'smartmontools'
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")

--- a/spec/classes/smartd_spec.rb
+++ b/spec/classes/smartd_spec.rb
@@ -22,20 +22,11 @@ describe 'smartd', :type => :class do
 
     it { should contain_package('smartmontools').with_ensure('present') }
     it do
-      should contain_service('smartd').with({
-        :ensure     => 'running',
-        :enable     => true,
-        :hasstatus  => true,
-        :hasrestart => true,
-      })
-    end
-    it do
       should contain_file(config_file).with({
         :ensure  => 'present',
         :owner   => 'root',
         :group   => 'root',
         :mode    => '0644',
-        :notify  => 'Service[smartd]'
       })
     end
     it "should contain File[#{config_file}] with correct contents" do
@@ -49,6 +40,8 @@ describe 'smartd', :type => :class do
 
       it_behaves_like 'default', {}
       it { should_not contain_shell_config('start_smartd') }
+      it { should contain_service('smartd').with_ensure('running').with_enable(true) }
+      it { should contain_file('/etc/smartd.conf').with_notify('Service[smartd]') }
     end
 
     describe 'for osfamily Debian' do
@@ -56,6 +49,8 @@ describe 'smartd', :type => :class do
 
       it_behaves_like 'default', {}
       it { should contain_shell_config('start_smartd') }
+      it { should contain_service('smartmontools').with_ensure('running').with_enable(true) }
+      it { should contain_file('/etc/smartd.conf').with_notify('Service[smartmontools]') }
     end
 
     describe 'for osfamily FreeBSD' do
@@ -63,6 +58,8 @@ describe 'smartd', :type => :class do
 
       it_behaves_like 'default', { :config_file => '/usr/local/etc/smartd.conf' }
       it { should_not contain_shell_config('start_smartd') }
+      it { should contain_service('smartd').with_ensure('running').with_enable(true) }
+      it { should contain_file('/usr/local/etc/smartd.conf').with_notify('Service[smartd]') }
     end
 
   end


### PR DESCRIPTION
Cool story: Somehow we have gotten away with this because on precise it has _both_ init scripts:
http://packages.ubuntu.com/precise/amd64/smartmontools/filelist

You can never have enough smartmontools init scripts, that's what I say.
