### PR TITLE
Remove shell_config dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,5 @@ fixtures:
     stdlib:
       repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
       ref:  '4.6.0'
-    shell_config: 'https://github.com/jhoblitt/shell_config.git'
   symlinks:
     smartd: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ The module includes a facter plugin to identify drives hiding behind an LSI
 MegaRAID/Dell PERC/Supermicro controller on Linux systems if you have the LSI
 proprietary `MegaCli` tool installed; we don't have any FreeBSD machines with
 this controller so haven't written the necessary code to use FreeBSD's standard
-`mfiutil(8)` utility instead.  The `shell_config` module is required to edit a
-Debian-specific configuration file; other OS families do not require it.
+`mfiutil(8)` utility instead.
 
 Currently, drives behind an LSI MegaRAID controller will be automatically
 probed and added to the `smartd` configuration file, if the `MegaCli` utility

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -181,11 +181,15 @@ class smartd (
   # Special sauce for Debian where it's not enough for the rc script
   # to be enabled, it also needs its own extra special config file.
   if $::osfamily == 'Debian' {
-    shell_config { 'start_smartd':
-      ensure  => $file_ensure,
-      file    => '/etc/default/smartmontools',
-      key     => 'start_smartd',
-      value   => 'yes',
+    $debian_augeas_changes = $svc_enable ? {
+      false   => 'remove start_smartd',
+      default => 'set start_smartd "yes"',
+    }
+
+    augeas { 'shell_config_start_smartd':
+      lens    => 'Shellvars.lns',
+      incl    => '/etc/default/smartmontools',
+      changes => $debian_augeas_changes,
       before  => Service[$service_name],
       require => Package[$package_name],
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,8 +23,13 @@ class smartd::params {
   $warning_schedule   = 'daily' # other choices: once, diminishing
   $default_options    = undef
 
+  $version_string = $::smartmontools_version ? {
+    undef   => '0.0',
+    default => $::smartmontools_version,
+  }
+
   # smartd.conf < 5.43 does not support the 'DEFAULT' directive
-  if versioncmp($::smartmontools_version, '5.43') >= 0 {
+  if versioncmp($version_string, '5.43') >= 0 {
     $enable_default = true
   } else {
     $enable_default = false

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,6 @@
     { "operatingsystem": "FreeBSD" }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 5.0.0" },
-    { "name": "csail/shell_config", "version_requirement": ">= 0.0.1" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.6.0 < 5.0.0" }
   ]
 }

--- a/spec/unit/classes/smartd_spec.rb
+++ b/spec/unit/classes/smartd_spec.rb
@@ -46,7 +46,7 @@ describe 'smartd', :type => :class do
       let(:facts) {{ :osfamily => 'SuSE', :smartmontools_version => '5.43', :gid => 'root' }}
 
       it_behaves_like 'default', {}
-      it { should_not contain_shell_config('start_smartd') }
+      it { should_not contain_augeas('shell_config_start_smartd') }
       it { should contain_service('smartd').with_ensure('running').with_enable(true) }
       it { should contain_file('/etc/smartd.conf').with_notify('Service[smartd]') }
     end
@@ -57,7 +57,7 @@ describe 'smartd', :type => :class do
           let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'RedHat', :operatingsystemmajrelease => '6', :smartmontools_version => '5.43', :gid => 'root' }}
 
           it_behaves_like 'default', {}
-          it { should_not contain_shell_config('start_smartd') }
+          it { should_not contain_augeas('shell_config_start_smartd') }
           it { should contain_service('smartd').with_ensure('running').with_enable(true) }
           it { should contain_file('/etc/smartd.conf').with_notify('Service[smartd]') }
         end
@@ -66,7 +66,7 @@ describe 'smartd', :type => :class do
           let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'RedHat', :operatingsystemmajrelease => '7', :smartmontools_version => '6.2', :gid => 'root' }}
 
           it_behaves_like 'default', { :config_file => '/etc/smartmontools/smartd.conf' }
-          it { should_not contain_shell_config('start_smartd') }
+          it { should_not contain_augeas('shell_config_start_smartd') }
           it { should contain_service('smartd').with_ensure('running').with_enable(true) }
           it { should contain_file('/etc/smartmontools/smartd.conf').with_notify('Service[smartd]') }
         end
@@ -77,7 +77,7 @@ describe 'smartd', :type => :class do
           let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '18', :smartmontools_version => '5.43', :gid => 'root' }}
 
           it_behaves_like 'default', {}
-          it { should_not contain_shell_config('start_smartd') }
+          it { should_not contain_augeas('shell_config_start_smartd') }
           it { should contain_service('smartd').with_ensure('running').with_enable(true) }
           it { should contain_file('/etc/smartd.conf').with_notify('Service[smartd]') }
         end
@@ -86,7 +86,7 @@ describe 'smartd', :type => :class do
           let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '19', :smartmontools_version => '6.1', :gid => 'root' }}
 
           it_behaves_like 'default', { :config_file => '/etc/smartmontools/smartd.conf' }
-          it { should_not contain_shell_config('start_smartd') }
+          it { should_not contain_augeas('shell_config_start_smartd') }
           it { should contain_service('smartd').with_ensure('running').with_enable(true) }
           it { should contain_file('/etc/smartmontools/smartd.conf').with_notify('Service[smartd]') }
         end
@@ -97,7 +97,7 @@ describe 'smartd', :type => :class do
       let(:facts) {{ :osfamily => 'Debian', :smartmontools_version => '5.43', :gid => 'root' }}
 
       it_behaves_like 'default', {}
-      it { should contain_shell_config('start_smartd') }
+      it { should contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       it { should contain_service('smartmontools').with_ensure('running').with_enable(true) }
       it { should contain_file('/etc/smartd.conf').with_notify('Service[smartmontools]') }
     end
@@ -106,7 +106,7 @@ describe 'smartd', :type => :class do
       let(:facts) {{ :osfamily => 'FreeBSD', :smartmontools_version => '5.43', :gid => 'wheel' }}
 
       it_behaves_like 'default', { :config_file => '/usr/local/etc/smartd.conf', :group => 'wheel' }
-      it { should_not contain_shell_config('start_smartd') }
+      it { should_not contain_augeas('shell_config_start_smartd') }
       it { should contain_service('smartd').with_ensure('running').with_enable(true) }
       it { should contain_file('/usr/local/etc/smartd.conf').with_notify('Service[smartd]') }
     end
@@ -114,369 +114,422 @@ describe 'smartd', :type => :class do
   end
 
   describe 'on a supported osfamily, custom parameters' do
-    let(:facts) {{ :osfamily => 'RedHat', :smartmontools_version => '5.43' }}
+    describe 'for osfamily RedHat' do
+      let(:facts) {{ :osfamily => 'RedHat', :smartmontools_version => '5.43' }}
 
-    describe 'ensure => present' do
-      let(:params) {{ :ensure => 'present' }}
+      describe 'ensure => present' do
+        let(:params) {{ :ensure => 'present' }}
 
-      it { should contain_package('smartmontools').with_ensure('present') }
-      it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-    end
-
-    describe 'ensure => latest' do
-      let(:params) {{ :ensure => 'latest' }}
-
-      it { should contain_package('smartmontools').with_ensure('latest') }
-      it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-    end
-
-    describe 'ensure => absent' do
-      let(:params) {{ :ensure => 'absent' }}
-
-      it { should contain_package('smartmontools').with_ensure('absent') }
-      it { should_not contain_service('smartd') }
-      it { should contain_file('/etc/smartd.conf').with_ensure('absent') }
-    end
-
-    describe 'ensure => purge' do
-      let(:params) {{ :ensure => 'purged' }}
-
-      it { should contain_package('smartmontools').with_ensure('purged') }
-      it { should_not contain_service('smartd') }
-      it { should contain_file('/etc/smartd.conf').with_ensure('absent') }
-    end
-
-    describe 'ensure => badvalue' do
-      let(:params) {{ :ensure => 'badvalue' }}
-
-      it 'should fail' do
-        expect {
-          should raise_error(Puppet::Error, /unsupported value of $ensure: badvalue/)
-        }
+        it { should contain_package('smartmontools').with_ensure('present') }
+        it { should contain_service('smartd').with_ensure('running').with_enable(true) }
+        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
       end
-    end
 
-    describe 'service_ensure => running' do
-      let(:params) {{ :service_ensure => 'running' }}
+      describe 'ensure => latest' do
+        let(:params) {{ :ensure => 'latest' }}
 
-      it { should contain_package('smartmontools').with_ensure('present') }
-      it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-    end
-
-    describe 'service_ensure => stopped' do
-      let(:params) {{ :service_ensure => 'stopped' }}
-
-      it { should contain_package('smartmontools').with_ensure('present') }
-      it { should contain_service('smartd').with_ensure('stopped').with_enable(false) }
-    end
-
-    describe 'manage_service => false' do
-      let(:params) {{ :manage_service => false }}
-
-      it { should_not contain_service('smartd') }
-    end
-
-    describe 'service_ensure => badvalue' do
-      let(:params) {{ :service_ensure => 'badvalue' }}
-
-      it 'should fail' do
-        expect {
-          should raise_error(Puppet::Error, /unsupported value of/)
-        }
+        it { should contain_package('smartmontools').with_ensure('latest') }
+        it { should contain_service('smartd').with_ensure('running').with_enable(true) }
+        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
       end
-    end
 
-    describe 'devicescan =>' do
-      context '(default)' do
-        it do
-          should contain_file('/etc/smartd.conf').
-            with_ensure('present').
-            with_content(/^DEVICESCAN$/)
+      describe 'ensure => absent' do
+        let(:params) {{ :ensure => 'absent' }}
+
+        it { should contain_package('smartmontools').with_ensure('absent') }
+        it { should_not contain_service('smartd') }
+        it { should contain_file('/etc/smartd.conf').with_ensure('absent') }
+      end
+
+      describe 'ensure => purge' do
+        let(:params) {{ :ensure => 'purged' }}
+
+        it { should contain_package('smartmontools').with_ensure('purged') }
+        it { should_not contain_service('smartd') }
+        it { should contain_file('/etc/smartd.conf').with_ensure('absent') }
+      end
+
+      describe 'ensure => badvalue' do
+        let(:params) {{ :ensure => 'badvalue' }}
+
+        it 'should fail' do
+          expect {
+            should raise_error(Puppet::Error, /unsupported value of $ensure: badvalue/)
+          }
         end
-      end # (default)
+      end
 
-      context 'true' do
-        let(:params) {{ :devicescan => true }}
+      describe 'service_ensure => running' do
+        let(:params) {{ :service_ensure => 'running' }}
 
-        it do
-          should contain_file('/etc/smartd.conf').
-            with_ensure('present').
-            with_content(/^DEVICESCAN$/)
+        it { should contain_package('smartmontools').with_ensure('present') }
+        it { should contain_service('smartd').with_ensure('running').with_enable(true) }
+      end
+
+      describe 'service_ensure => stopped' do
+        let(:params) {{ :service_ensure => 'stopped' }}
+
+        it { should contain_package('smartmontools').with_ensure('present') }
+        it { should contain_service('smartd').with_ensure('stopped').with_enable(false) }
+      end
+
+      describe 'manage_service => false' do
+        let(:params) {{ :manage_service => false }}
+
+        it { should_not contain_service('smartd') }
+      end
+
+      describe 'service_ensure => badvalue' do
+        let(:params) {{ :service_ensure => 'badvalue' }}
+
+        it 'should fail' do
+          expect {
+            should raise_error(Puppet::Error, /unsupported value of/)
+          }
         end
+      end
 
-        context 'enable_default => false' do
-          before { params[:enable_default] = false }
-
-          it 'should have the same arguments as DEFAULT would have' do
+      describe 'devicescan =>' do
+        context '(default)' do
+          it do
             should contain_file('/etc/smartd.conf').
               with_ensure('present').
-              with_content(/^DEVICESCAN -m root -M daily$/)
+              with_content(/^DEVICESCAN$/)
+          end
+        end # (default)
+
+        context 'true' do
+          let(:params) {{ :devicescan => true }}
+
+          it do
+            should contain_file('/etc/smartd.conf').
+              with_ensure('present').
+              with_content(/^DEVICESCAN$/)
+          end
+
+          context 'enable_default => false' do
+            before { params[:enable_default] = false }
+
+            it 'should have the same arguments as DEFAULT would have' do
+              should contain_file('/etc/smartd.conf').
+                with_ensure('present').
+                with_content(/^DEVICESCAN -m root -M daily$/)
+            end
+          end
+        end # true
+
+        context 'false' do
+          let(:params) {{ :devicescan => false }}
+
+          it do
+            should contain_file('/etc/smartd.conf').
+              with_ensure('present').
+              without_content(/^DEVICESCAN$/)
+          end
+        end # false
+
+        context 'foo' do
+          let(:params) {{ :devicescan => 'foo' }}
+          it 'should fail' do
+            expect {
+              should raise_error(Puppet::Error, /is not a boolean../)
+            }
           end
         end
-      end # true
+      end # devicescan =>
 
-      context 'false' do
-        let(:params) {{ :devicescan => false }}
+      describe 'devicescan_options => somevalue' do
+        let(:params) {{ :devicescan_options => 'somevalue' }}
 
-        it do
-          should contain_file('/etc/smartd.conf').
-            with_ensure('present').
-            without_content(/^DEVICESCAN$/)
+        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it 'should contain file /etc/smartd.conf with contents ...' do
+          verify_contents(catalogue, '/etc/smartd.conf', [
+            'DEFAULT -m root -M daily',
+            'DEVICESCAN somevalue',
+          ])
         end
-      end # false
+      end
 
-      context 'foo' do
-        let(:params) {{ :devicescan => 'foo' }}
+      describe 'devices without options' do
+        let(:params) do
+          {
+            'devices' => [
+              { 'device' => '/dev/sg1' },
+              { 'device' => '/dev/sg2' },
+            ],
+          }
+        end
+
+        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it 'should contain file /etc/smartd.conf with contents ...' do
+          verify_contents(catalogue, '/etc/smartd.conf', [
+            'DEFAULT -m root -M daily',
+            '/dev/sg1',
+            '/dev/sg2',
+          ])
+        end
+      end
+
+      describe 'devices with options"' do
+        let :params do
+          {
+            'devices' => [
+              { 'device' => '/dev/sg1', 'options' => '-o on -S on -a' },
+              { 'device' => '/dev/sg2', 'options' => '-o on -S on -a' },
+            ],
+          }
+        end
+
+        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it 'should contain file /etc/smartd.conf with contents ...' do
+          verify_contents(catalogue, '/etc/smartd.conf', [
+            'DEFAULT -m root -M daily',
+            '/dev/sg1 -o on -S on -a',
+            '/dev/sg2 -o on -S on -a',
+          ])
+        end
+      end
+
+      describe 'devices with options"' do
+        let :params do
+          {
+            'devices' => [
+              { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,0 -a -o on -S on' },
+              { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,1 -a -o on -S on' },
+              { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,2 -a -o on -S on' },
+              { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,3 -a -o on -S on' },
+              { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,4 -a -o on -S on' },
+              { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,5 -a -o on -S on' },
+
+            ],
+          }
+        end
+
+        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it 'should contain file /etc/smartd.conf with contents ...' do
+          verify_contents(catalogue, '/etc/smartd.conf', [
+            'DEFAULT -m root -M daily',
+            '/dev/cciss/c0d0 -d cciss,0 -a -o on -S on',
+            '/dev/cciss/c0d0 -d cciss,1 -a -o on -S on',
+            '/dev/cciss/c0d0 -d cciss,2 -a -o on -S on',
+            '/dev/cciss/c0d0 -d cciss,3 -a -o on -S on',
+            '/dev/cciss/c0d0 -d cciss,4 -a -o on -S on',
+            '/dev/cciss/c0d0 -d cciss,5 -a -o on -S on',
+          ])
+        end
+      end
+
+      describe 'mail_to => someguy@localdomain' do
+        let(:params) {{ :mail_to => 'someguy@localdomain' }}
+
+        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it 'should contain file /etc/smartd.conf with contents ...' do
+          verify_contents(catalogue, '/etc/smartd.conf', [
+            'DEFAULT -m someguy@localdomain -M daily',
+          ])
+        end
+      end
+
+      describe 'warning_schedule => diminishing' do
+        let(:params) {{ :warning_schedule => 'diminishing' }}
+
+        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it 'should contain file /etc/smartd.conf with contents ...' do
+          verify_contents(catalogue, '/etc/smartd.conf', [
+            'DEFAULT -m root -M diminishing',
+          ])
+        end
+      end
+
+      describe 'warning_schedule => badvalue' do
+        let(:params) {{ :warning_schedule => 'badvalue' }}
+
         it 'should fail' do
           expect {
-            should raise_error(Puppet::Error, /is not a boolean../)
+            should raise_error(Puppet::Error, /$warning_schedule must be either daily, once, or diminishing./)
           }
         end
       end
-    end # devicescan =>
 
-    describe 'devicescan_options => somevalue' do
-      let(:params) {{ :devicescan_options => 'somevalue' }}
+      describe 'enable_default => ' do
+        context '(default)' do
+          context 'fact smartmontool_version = "5.43"' do
+            before { facts[:smartmontools_version] = '5.43' }
+            it do
+              should contain_file('/etc/smartd.conf').with_ensure('present').
+                with_content(/DEFAULT -m root -M daily/)
+            end
+          end
 
-      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain file /etc/smartd.conf with contents ...' do
-        verify_contents(catalogue, '/etc/smartd.conf', [
-          'DEFAULT -m root -M daily',
-          'DEVICESCAN somevalue',
-        ])
-      end
-    end
+          context 'fact smartmontool_version = "5.42"' do
+            before { facts[:smartmontools_version] = '5.42' }
+            it do
+              should contain_file('/etc/smartd.conf').with_ensure('present').
+                without_content(/DEFAULT -m root -M daily/).
+                with_content(/DEVICESCAN -m root -M daily/)
+            end
+          end
+        end # (default)
 
-    describe 'devices without options' do
-      let(:params) do
-        {
-          'devices' => [
-            { 'device' => '/dev/sg1' },
-            { 'device' => '/dev/sg2' },
-          ],
-        }
-      end
-
-      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain file /etc/smartd.conf with contents ...' do
-        verify_contents(catalogue, '/etc/smartd.conf', [
-          'DEFAULT -m root -M daily',
-          '/dev/sg1',
-          '/dev/sg2',
-        ])
-      end
-    end
-
-    describe 'devices with options"' do
-      let :params do
-        {
-          'devices' => [
-            { 'device' => '/dev/sg1', 'options' => '-o on -S on -a' },
-            { 'device' => '/dev/sg2', 'options' => '-o on -S on -a' },
-          ],
-        }
-      end
-
-      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain file /etc/smartd.conf with contents ...' do
-        verify_contents(catalogue, '/etc/smartd.conf', [
-          'DEFAULT -m root -M daily',
-          '/dev/sg1 -o on -S on -a',
-          '/dev/sg2 -o on -S on -a',
-        ])
-      end
-    end
-
-    describe 'devices with options"' do
-      let :params do
-        {
-          'devices' => [
-            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,0 -a -o on -S on' },
-            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,1 -a -o on -S on' },
-            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,2 -a -o on -S on' },
-            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,3 -a -o on -S on' },
-            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,4 -a -o on -S on' },
-            { 'device' => '/dev/cciss/c0d0', 'options' => '-d cciss,5 -a -o on -S on' },
-
-          ],
-        }
-      end
-
-      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain file /etc/smartd.conf with contents ...' do
-        verify_contents(catalogue, '/etc/smartd.conf', [
-          'DEFAULT -m root -M daily',
-          '/dev/cciss/c0d0 -d cciss,0 -a -o on -S on',
-          '/dev/cciss/c0d0 -d cciss,1 -a -o on -S on',
-          '/dev/cciss/c0d0 -d cciss,2 -a -o on -S on',
-          '/dev/cciss/c0d0 -d cciss,3 -a -o on -S on',
-          '/dev/cciss/c0d0 -d cciss,4 -a -o on -S on',
-          '/dev/cciss/c0d0 -d cciss,5 -a -o on -S on',
-        ])
-      end
-    end
-
-    describe 'mail_to => someguy@localdomain' do
-      let(:params) {{ :mail_to => 'someguy@localdomain' }}
-
-      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain file /etc/smartd.conf with contents ...' do
-        verify_contents(catalogue, '/etc/smartd.conf', [
-          'DEFAULT -m someguy@localdomain -M daily',
-        ])
-      end
-    end
-
-    describe 'warning_schedule => diminishing' do
-      let(:params) {{ :warning_schedule => 'diminishing' }}
-
-      it { should contain_file('/etc/smartd.conf').with_ensure('present') }
-      it 'should contain file /etc/smartd.conf with contents ...' do
-        verify_contents(catalogue, '/etc/smartd.conf', [
-          'DEFAULT -m root -M diminishing',
-        ])
-      end
-    end
-
-    describe 'warning_schedule => badvalue' do
-      let(:params) {{ :warning_schedule => 'badvalue' }}
-
-      it 'should fail' do
-        expect {
-          should raise_error(Puppet::Error, /$warning_schedule must be either daily, once, or diminishing./)
-        }
-      end
-    end
-
-    describe 'enable_default => ' do
-      context '(default)' do
-        context 'fact smartmontool_version = "5.43"' do
-          before { facts[:smartmontools_version] = '5.43' }
+        context 'true' do
+          let(:params) {{ :enable_default => true }}
           it do
             should contain_file('/etc/smartd.conf').with_ensure('present').
               with_content(/DEFAULT -m root -M daily/)
           end
         end
 
-        context 'fact smartmontool_version = "5.42"' do
-          before { facts[:smartmontools_version] = '5.42' }
+        context 'false' do
+          let(:params) {{ :enable_default => false }}
           it do
             should contain_file('/etc/smartd.conf').with_ensure('present').
               without_content(/DEFAULT -m root -M daily/).
               with_content(/DEVICESCAN -m root -M daily/)
           end
         end
-      end # (default)
 
-      context 'true' do
-        let(:params) {{ :enable_default => true }}
-        it do
-          should contain_file('/etc/smartd.conf').with_ensure('present').
-            with_content(/DEFAULT -m root -M daily/)
+        context 'foo' do
+          let(:params) {{ :enable_default => 'foo' }}
+          it 'should fail' do
+            expect {
+              should raise_error(Puppet::Error, /is not a boolean../)
+            }
+          end
         end
+      end # enable_default =>
+
+      describe 'default_options => ' do
+        context '(default)' do
+          let(:params) {{ }}
+
+          context 'default => true' do
+            before { params[:enable_default] = true }
+
+            it do
+              should contain_file('/etc/smartd.conf').with_ensure('present').
+                with_content(/DEFAULT -m root -M daily/)
+            end
+          end
+
+          context 'enable_default => false' do
+            before { params[:enable_default] = false }
+
+            it do
+              should contain_file('/etc/smartd.conf').with_ensure('present').
+                without_content(/DEFAULT -m root -M daily/).
+                with_content(/DEVICESCAN -m root -M daily/)
+            end
+          end
+        end # (default)
+
+        context 'undef' do
+          let(:params) {{ :default_options => nil }}
+
+          context 'enable_default => true' do
+            before { params[:enable_default] = true }
+
+            it do
+              should contain_file('/etc/smartd.conf').with_ensure('present').
+                with_content(/DEFAULT -m root -M daily/)
+            end
+          end
+
+          context 'enable_default => false' do
+            before { params[:enable_default] = false }
+
+            it do
+              should contain_file('/etc/smartd.conf').with_ensure('present').
+                without_content(/DEFAULT -m root -M daily/).
+                with_content(/DEVICESCAN -m root -M daily/)
+            end
+          end
+        end # undef
+
+        context '-H' do
+          let(:params) {{ :default_options => '-H'}}
+
+          context 'enable_default => true' do
+            before { params[:enable_default] = true }
+
+            it do
+              should contain_file('/etc/smartd.conf').with_ensure('present').
+                with_content(/DEFAULT -m root -M daily -H/)
+            end
+          end
+
+          context 'enable_default => false' do
+            before { params[:enable_default] = false }
+
+            it do
+              should contain_file('/etc/smartd.conf').with_ensure('present').
+                without_content(/DEFAULT -m root -M daily -H/).
+                with_content(/DEVICESCAN -m root -M daily -H/)
+            end
+          end
+        end # -H
+
+        context '[]' do
+          let(:params) {{ :default_options => [] }}
+          it 'should fail' do
+            expect {
+              should raise_error(Puppet::Error, /is not an Array../)
+            }
+          end
+        end # []
+      end # default_options =>
+    end
+
+    describe 'for osfamily Debian' do
+      let(:facts) {{ :osfamily => 'Debian', :smartmontools_version => '5.43' }}
+
+      describe 'ensure => present' do
+        let(:params) {{ :ensure => 'present' }}
+
+        it { should contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       end
 
-      context 'false' do
-        let(:params) {{ :enable_default => false }}
-        it do
-          should contain_file('/etc/smartd.conf').with_ensure('present').
-            without_content(/DEFAULT -m root -M daily/).
-            with_content(/DEVICESCAN -m root -M daily/)
-        end
+      describe 'ensure => latest' do
+        let(:params) {{ :ensure => 'latest' }}
+
+        it { should contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       end
 
-      context 'foo' do
-        let(:params) {{ :enable_default => 'foo' }}
-        it 'should fail' do
-          expect {
-            should raise_error(Puppet::Error, /is not a boolean../)
-          }
-        end
+      describe 'ensure => absent' do
+        let(:params) {{ :ensure => 'absent' }}
+
+        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
-    end # enable_default =>
 
-    describe 'default_options => ' do
-      context '(default)' do
-        let(:params) {{ }}
+      describe 'ensure => purged' do
+        let(:params) {{ :ensure => 'purged' }}
 
-        context 'default => true' do
-          before { params[:enable_default] = true }
+        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+      end
 
-          it do
-            should contain_file('/etc/smartd.conf').with_ensure('present').
-              with_content(/DEFAULT -m root -M daily/)
-          end
-        end
+      describe 'ensure => absent and service_ensure => running' do
+        let(:params) {{ :ensure => 'absent',  :service_ensure => 'running' }}
 
-        context 'enable_default => false' do
-          before { params[:enable_default] = false }
+        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+      end
 
-          it do
-            should contain_file('/etc/smartd.conf').with_ensure('present').
-              without_content(/DEFAULT -m root -M daily/).
-              with_content(/DEVICESCAN -m root -M daily/)
-          end
-        end
-      end # (default)
+      describe 'ensure => purged and service_ensure => running' do
+        let(:params) {{ :ensure => 'purged',  :service_ensure => 'running' }}
 
-      context 'undef' do
-        let(:params) {{ :default_options => nil }}
+        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+      end
 
-        context 'enable_default => true' do
-          before { params[:enable_default] = true }
+      describe 'service_ensure => running' do
+        let(:params) {{ :service_ensure => 'running' }}
 
-          it do
-            should contain_file('/etc/smartd.conf').with_ensure('present').
-              with_content(/DEFAULT -m root -M daily/)
-          end
-        end
+        it { should contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
+      end
 
-        context 'enable_default => false' do
-          before { params[:enable_default] = false }
+      describe 'service_ensure => stopped' do
+        let(:params) {{ :service_ensure => 'stopped' }}
 
-          it do
-            should contain_file('/etc/smartd.conf').with_ensure('present').
-              without_content(/DEFAULT -m root -M daily/).
-              with_content(/DEVICESCAN -m root -M daily/)
-          end
-        end
-      end # undef
-
-      context '-H' do
-        let(:params) {{ :default_options => '-H'}}
-
-        context 'enable_default => true' do
-          before { params[:enable_default] = true }
-
-          it do
-            should contain_file('/etc/smartd.conf').with_ensure('present').
-              with_content(/DEFAULT -m root -M daily -H/)
-          end
-        end
-
-        context 'enable_default => false' do
-          before { params[:enable_default] = false }
-
-          it do
-            should contain_file('/etc/smartd.conf').with_ensure('present').
-              without_content(/DEFAULT -m root -M daily -H/).
-              with_content(/DEVICESCAN -m root -M daily -H/)
-          end
-        end
-      end # -H
-
-      context '[]' do
-        let(:params) {{ :default_options => [] }}
-        it 'should fail' do
-          expect {
-            should raise_error(Puppet::Error, /is not an Array../)
-          }
-        end
-      end # []
-    end # default_options =>
-
+        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+      end
+    end
   end
 
 


### PR DESCRIPTION
This replaces the `shell_config` resource on Debian-based systems with
an equivalent `augeas` resource.  It also changes it to depend on the
value of the `$svc_enable` variable instead of `$file_ensure`, bringing
it in-line with its purpose.