### PR TITLE
Major spec cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,27 @@
+---
+inherit_from: .rubocop_todo.yml
+
+AllCops:
+  Exclude:
+    # Ignore HTML related things
+    - '**/*.erb'
+    # Ignore vendored gems
+    - 'vendor/**/*'
+    # Ignore code from test fixtures
+    - 'spec/fixtures/**/*'
+  TargetRubyVersion: 1.9
+
+# Follow the Puppet Style Guide for trailing commas
+# (except in arguments lists, which is incompatible with Ruby 1.8)
+#Style/TrailingCommaInArguments:
+#  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+# Always prefer Puppet-style regex delimiters
+Style/RegexpLiteral:
+  AllowInnerSlashes: true
+
+# Use the line lenght specified in the Puppet Sytle Guide
+Metrics/LineLength:
+  Max: 140

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,0 +1,7 @@
+---
+# Until Ruby 1.8 support is dropped...
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/DotPosition:
+  EnforcedStyle: trailing

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   - PUPPET_GEM_VERSION="~> 3.7"
   - PUPPET_GEM_VERSION="~> 4.0"
 matrix:
+  include:
+    - rvm: 2.2
+      script: 'bundle exec rake rubocop'
   exclude:
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,20 @@
 source 'https://rubygems.org'
 
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
-else
-  gem 'puppet', :require => false
-end
-
-if facterversion = ENV['FACTER_GEM_VERSION']
-  gem 'facter', facterversion, :require => false
-else
-  gem 'facter', :require => false
-end
+gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
+gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false
 
 group :development, :test do
-  gem 'rake', '~> 10.5',           :require => false
   # https://github.com/rspec/rspec-core/issues/1864
-  gem 'rspec', '< 3.2.0', {"platforms"=>["ruby_18"]}
+  gem 'rspec', '< 3.2.0', 'platforms' => ['ruby_18']
+  gem 'rake', '~> 10.5',          :require => false
   gem 'puppetlabs_spec_helper',   :require => false
   gem 'puppet-lint', '>= 1.1.0',  :require => false
   gem 'puppet-syntax',            :require => false
   gem 'rspec-puppet', '~> 2.2',   :require => false
   gem 'metadata-json-lint',       :require => false
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
+    gem 'rubocop', :require => false
+  end
 end
 
 group :beaker do

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,12 @@ require 'puppet-lint/tasks/puppet-lint'
 
 begin
   require 'puppet_blacksmith/rake_tasks'
-rescue LoadError
+rescue LoadError # rubocop:disable Lint/HandleExceptions
+end
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2')
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
 end
 
 PuppetSyntax.exclude_paths = ['spec/fixtures/**/*']
@@ -15,7 +20,7 @@ PuppetLint::RakeTask.new :lint do |config|
 end
 
 task :travis_lint do
-  sh "travis-lint"
+  sh 'travis-lint'
 end
 
 task :default => [

--- a/lib/facter/megacli.rb
+++ b/lib/facter/megacli.rb
@@ -1,14 +1,14 @@
 Facter.add(:megacli) do
   confine :kernel => :linux
 
-  megacli_binaries = ['MegaCli', 'megacli']
+  megacli_binaries = %w(MegaCli megacli)
 
   setcode do
     path = nil
     megacli_binaries.each do |bin|
-        path = Facter::Util::Resolution.which(bin)
-        next if path.nil?
-        break
+      path = Facter::Util::Resolution.which(bin)
+      next if path.nil?
+      break
     end
     path
   end

--- a/lib/facter/megacli_legacy.rb
+++ b/lib/facter/megacli_legacy.rb
@@ -16,6 +16,5 @@ Facter.add(:megacli_legacy) do
     modern_version = SemVer.new('8.02.16')
 
     actual_version < modern_version
-
   end
 end

--- a/lib/facter/megaraid_adapters.rb
+++ b/lib/facter/megaraid_adapters.rb
@@ -11,12 +11,10 @@ Facter.add(:megaraid_adapters) do
   setcode do
     megacli = Facter.value(:megacli)
 
-    if megacli.nil?
-      next nil
-    end
+    next if megacli.nil?
 
     # -adpCount sends it's entire output to the stderr
     count = Facter::Util::Resolution.exec("#{megacli} -adpCount -NoLog 2>&1")
-    count =~ /Controller Count:\s+(\d+)\./ ? $1 : '0'
+    count =~ /Controller Count:\s+(\d+)\./ ? Regexp.last_match(1) : '0'
   end
 end

--- a/lib/facter/megaraid_fw_package_build.rb
+++ b/lib/facter/megaraid_fw_package_build.rb
@@ -13,7 +13,6 @@ Facter.add(:megaraid_fw_package_build) do
   end
 end
 
-
 Facter.add(:megaraid_fw_package_build) do
   confine :megacli_legacy => true
 

--- a/lib/facter/megaraid_fw_version.rb
+++ b/lib/facter/megaraid_fw_version.rb
@@ -13,7 +13,6 @@ Facter.add(:megaraid_fw_version) do
   end
 end
 
-
 Facter.add(:megaraid_fw_version) do
   confine :megacli_legacy => true
 

--- a/lib/facter/megaraid_physical_drives.rb
+++ b/lib/facter/megaraid_physical_drives.rb
@@ -5,23 +5,18 @@ Facter.add(:megaraid_physical_drives) do
     megacli           = Facter.value(:megacli)
     megaraid_adapters = Facter.value(:megaraid_adapters)
 
-    if megacli.nil? ||
-      megaraid_adapters.nil? || (megaraid_adapters == 0)
-      next nil
-    end
+    next if megacli.nil? || megaraid_adapters.nil? || (megaraid_adapters == 0)
 
     # XXX there is no support for handling more than one adapter
     pds = []
     list = Facter::Util::Resolution.exec("#{megacli} -PDList -aALL -NoLog")
     next if list.nil?
     list.each_line do |line|
-      if line =~ /^Device Id:\s+(\d+)/
-        pds.push($1)
-      end
+      pds.push(Regexp.last_match(1)) if line =~ /^Device Id:\s+(\d+)/
     end
 
     # sort the device IDs numerically on the assumption that they are always
     # integers
-    pds.sort {|a,b| a.to_i <=> b.to_i}.join(",")
+    pds.sort { |a, b| a.to_i <=> b.to_i }.join(',')
   end
 end

--- a/lib/facter/megaraid_physical_drives_sas.rb
+++ b/lib/facter/megaraid_physical_drives_sas.rb
@@ -5,10 +5,7 @@ Facter.add(:megaraid_physical_drives_sas) do
     megacli           = Facter.value(:megacli)
     megaraid_adapters = Facter.value(:megaraid_adapters)
 
-    if megacli.nil? ||
-      megaraid_adapters.nil? || (megaraid_adapters == 0)
-      next nil
-    end
+    next if megacli.nil? || megaraid_adapters.nil? || (megaraid_adapters == 0)
 
     # XXX there is no support for handling more than one adapter
     pds = []
@@ -17,19 +14,15 @@ Facter.add(:megaraid_physical_drives_sas) do
 
     dev_id = nil
     list.each_line do |line|
-      if line =~ /^Device Id:\s+(\d+)/
-        dev_id = $1
-      end
+      dev_id = Regexp.last_match(1) if line =~ /^Device Id:\s+(\d+)/
       if line =~ /^PD Type:\s+(\w+)/
-        type = $1
-        if type == 'SAS'
-          pds.push(dev_id)
-        end
+        type = Regexp.last_match(1)
+        pds.push(dev_id) if type == 'SAS'
       end
     end
 
     # sort the device IDs numerically on the assumption that they are always
     # integers
-    pds.sort {|a,b| a.to_i <=> b.to_i}.join(",")
+    pds.sort { |a, b| a.to_i <=> b.to_i }.join(',')
   end
 end

--- a/lib/facter/megaraid_physical_drives_sata.rb
+++ b/lib/facter/megaraid_physical_drives_sata.rb
@@ -5,10 +5,7 @@ Facter.add(:megaraid_physical_drives_sata) do
     megacli           = Facter.value(:megacli)
     megaraid_adapters = Facter.value(:megaraid_adapters)
 
-    if megacli.nil? ||
-      megaraid_adapters.nil? || (megaraid_adapters == 0)
-      next nil
-    end
+    next if megacli.nil? || megaraid_adapters.nil? || (megaraid_adapters == 0)
 
     # XXX there is no support for handling more than one adapter
     pds = []
@@ -17,19 +14,15 @@ Facter.add(:megaraid_physical_drives_sata) do
 
     dev_id = nil
     list.each_line do |line|
-      if line =~ /^Device Id:\s+(\d+)/
-        dev_id = $1
-      end
+      dev_id = Regexp.last_match(1) if line =~ /^Device Id:\s+(\d+)/
       if line =~ /^PD Type:\s+(\w+)/
-        type = $1
-        if type == 'SATA'
-          pds.push(dev_id)
-        end
+        type = Regexp.last_match(1)
+        pds.push(dev_id) if type == 'SATA'
       end
     end
 
     # sort the device IDs numerically on the assumption that they are always
     # integers
-    pds.sort {|a,b| a.to_i <=> b.to_i}.join(",")
+    pds.sort { |a, b| a.to_i <=> b.to_i }.join(',')
   end
 end

--- a/lib/facter/megaraid_physical_drives_size.rb
+++ b/lib/facter/megaraid_physical_drives_size.rb
@@ -5,19 +5,14 @@ Facter.add(:megaraid_physical_drives_size) do
     megacli           = Facter.value(:megacli)
     megaraid_adapters = Facter.value(:megaraid_adapters)
 
-    if megacli.nil? ||
-      megaraid_adapters.nil? || (megaraid_adapters == 0)
-      next nil
-    end
+    next if megacli.nil? || megaraid_adapters.nil? || (megaraid_adapters == 0)
 
     # XXX there is no support for handling more than one adapter
     sizes = []
     list = Facter::Util::Resolution.exec("#{megacli} -PDList -aALL -NoLog")
     next if list.nil?
     list.each_line do |line|
-      if line =~ /Raw Size: ([\.\d]+ [A-Z]?B)/
-        sizes.push($1)
-      end
+      sizes.push(Regexp.last_match(1)) if line =~ /Raw Size: ([\.\d]+ [A-Z]?B)/
     end
 
     sizes.join(',')

--- a/lib/facter/megaraid_product_name.rb
+++ b/lib/facter/megaraid_product_name.rb
@@ -13,7 +13,6 @@ Facter.add(:megaraid_product_name) do
   end
 end
 
-
 Facter.add(:megaraid_product_name) do
   confine :megacli_legacy => true
 

--- a/lib/facter/megaraid_serial.rb
+++ b/lib/facter/megaraid_serial.rb
@@ -13,7 +13,6 @@ Facter.add(:megaraid_serial) do
   end
 end
 
-
 Facter.add(:megaraid_serial) do
   confine :megacli_legacy => true
 

--- a/lib/facter/megaraid_virtual_drives.rb
+++ b/lib/facter/megaraid_virtual_drives.rb
@@ -12,11 +12,8 @@ Facter.add(:megaraid_virtual_drives) do
     megaraid_adapters = Facter.value(:megaraid_adapters)
     blockdevices      = Facter.value(:blockdevices)
 
-    if megacli.nil? ||
-      megaraid_adapters.nil? || (megaraid_adapters == 0) ||
-      blockdevices.nil?
-      next nil
-    end
+    next if megacli.nil? || megaraid_adapters.nil? ||
+            (megaraid_adapters == 0) || blockdevices.nil?
 
     vds = []
 
@@ -29,7 +26,7 @@ Facter.add(:megaraid_virtual_drives) do
       end
     end
 
-    next nil if vds.empty?
+    next if vds.empty?
     vds.sort.join(',')
   end
 end

--- a/spec/unit/classes/params_spec.rb
+++ b/spec/unit/classes/params_spec.rb
@@ -1,9 +1,8 @@
 require 'spec_helper'
 
 describe 'smartd::params', :type => :class do
-
   shared_examples 'osfamily' do |family|
-    let(:facts) {{ :osfamily => family }}
+    let(:facts) { { :osfamily => family } }
 
     it { is_expected.to contain_class('smartd::params') }
   end
@@ -33,5 +32,4 @@ describe 'smartd::params', :type => :class do
         to raise_error(Puppet::Error, /not supported on Solaris/)
     end
   end
-
 end

--- a/spec/unit/classes/params_spec.rb
+++ b/spec/unit/classes/params_spec.rb
@@ -5,7 +5,7 @@ describe 'smartd::params', :type => :class do
   shared_examples 'osfamily' do |family|
     let(:facts) {{ :osfamily => family }}
 
-    it { should contain_class('smartd::params') }
+    it { is_expected.to contain_class('smartd::params') }
   end
 
   describe 'for osfamily RedHat' do
@@ -29,7 +29,7 @@ describe 'smartd::params', :type => :class do
     end
 
     it 'should fail' do
-      expect { should contain_class('smartd::params') }.
+      expect { is_expected.to contain_class('smartd::params') }.
         to raise_error(Puppet::Error, /not supported on Solaris/)
     end
   end

--- a/spec/unit/classes/smartd_spec.rb
+++ b/spec/unit/classes/smartd_spec.rb
@@ -27,9 +27,9 @@ describe 'smartd', :type => :class do
       group = 'root'
     end
 
-    it { should contain_package('smartmontools').with_ensure('present') }
+    it { is_expected.to contain_package('smartmontools').with_ensure('present') }
     it do
-      should contain_file(config_file).with({
+      is_expected.to contain_file(config_file).with({
         :ensure  => 'present',
         :owner   => 'root',
         :group   => group,
@@ -46,9 +46,9 @@ describe 'smartd', :type => :class do
       let(:facts) {{ :osfamily => 'SuSE', :smartmontools_version => '5.43', :gid => 'root' }}
 
       it_behaves_like 'default', {}
-      it { should_not contain_augeas('shell_config_start_smartd') }
-      it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-      it { should contain_service('smartd').with_subscribe('File[/etc/smartd.conf]') }
+      it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
+      it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
+      it { is_expected.to contain_service('smartd').with_subscribe('File[/etc/smartd.conf]') }
     end
 
     describe 'for osfamily RedHat' do
@@ -57,18 +57,18 @@ describe 'smartd', :type => :class do
           let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'RedHat', :operatingsystemmajrelease => '6', :smartmontools_version => '5.43', :gid => 'root' }}
 
           it_behaves_like 'default', {}
-          it { should_not contain_augeas('shell_config_start_smartd') }
-          it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-          it { should contain_service('smartd').with_subscribe('File[/etc/smartd.conf]') }
+          it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
+          it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
+          it { is_expected.to contain_service('smartd').with_subscribe('File[/etc/smartd.conf]') }
         end
 
         describe 'for operatingsystemmajrelease 7' do
           let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'RedHat', :operatingsystemmajrelease => '7', :smartmontools_version => '6.2', :gid => 'root' }}
 
           it_behaves_like 'default', { :config_file => '/etc/smartmontools/smartd.conf' }
-          it { should_not contain_augeas('shell_config_start_smartd') }
-          it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-          it { should contain_service('smartd').with_subscribe('File[/etc/smartmontools/smartd.conf]') }
+          it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
+          it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
+          it { is_expected.to contain_service('smartd').with_subscribe('File[/etc/smartmontools/smartd.conf]') }
         end
       end
 
@@ -77,18 +77,18 @@ describe 'smartd', :type => :class do
           let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '18', :smartmontools_version => '5.43', :gid => 'root' }}
 
           it_behaves_like 'default', {}
-          it { should_not contain_augeas('shell_config_start_smartd') }
-          it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-          it { should contain_service('smartd').with_subscribe('File[/etc/smartd.conf]') }
+          it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
+          it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
+          it { is_expected.to contain_service('smartd').with_subscribe('File[/etc/smartd.conf]') }
         end
 
         describe 'for operatingsystemrelease 19' do
           let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '19', :smartmontools_version => '6.1', :gid => 'root' }}
 
           it_behaves_like 'default', { :config_file => '/etc/smartmontools/smartd.conf' }
-          it { should_not contain_augeas('shell_config_start_smartd') }
-          it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-          it { should contain_service('smartd').with_subscribe('File[/etc/smartmontools/smartd.conf]') }
+          it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
+          it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
+          it { is_expected.to contain_service('smartd').with_subscribe('File[/etc/smartmontools/smartd.conf]') }
         end
       end
     end
@@ -97,18 +97,18 @@ describe 'smartd', :type => :class do
       let(:facts) {{ :osfamily => 'Debian', :smartmontools_version => '5.43', :gid => 'root' }}
 
       it_behaves_like 'default', {}
-      it { should contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
-      it { should contain_service('smartmontools').with_ensure('running').with_enable(true) }
-      it { should contain_service('smartmontools').with_subscribe('File[/etc/smartd.conf]') }
+      it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
+      it { is_expected.to contain_service('smartmontools').with_ensure('running').with_enable(true) }
+      it { is_expected.to contain_service('smartmontools').with_subscribe('File[/etc/smartd.conf]') }
     end
 
     describe 'for osfamily FreeBSD' do
       let(:facts) {{ :osfamily => 'FreeBSD', :smartmontools_version => '5.43', :gid => 'wheel' }}
 
       it_behaves_like 'default', { :config_file => '/usr/local/etc/smartd.conf', :group => 'wheel' }
-      it { should_not contain_augeas('shell_config_start_smartd') }
-      it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-      it { should contain_service('smartd').with_subscribe('File[/usr/local/etc/smartd.conf]') }
+      it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
+      it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
+      it { is_expected.to contain_service('smartd').with_subscribe('File[/usr/local/etc/smartd.conf]') }
     end
 
   end
@@ -120,33 +120,33 @@ describe 'smartd', :type => :class do
       describe 'ensure => present' do
         let(:params) {{ :ensure => 'present' }}
 
-        it { should contain_package('smartmontools').with_ensure('present') }
-        it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-        it { should contain_service('smartd').with_subscribe('File[/etc/smartd.conf]') }
+        it { is_expected.to contain_package('smartmontools').with_ensure('present') }
+        it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
+        it { is_expected.to contain_service('smartd').with_subscribe('File[/etc/smartd.conf]') }
       end
 
       describe 'ensure => latest' do
         let(:params) {{ :ensure => 'latest' }}
 
-        it { should contain_package('smartmontools').with_ensure('latest') }
-        it { should contain_service('smartd').with_ensure('running').with_enable(true) }
-        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it { is_expected.to contain_package('smartmontools').with_ensure('latest') }
+        it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
       end
 
       describe 'ensure => absent' do
         let(:params) {{ :ensure => 'absent' }}
 
-        it { should contain_package('smartmontools').with_ensure('absent') }
-        it { should_not contain_service('smartd') }
-        it { should contain_file('/etc/smartd.conf').with_ensure('absent') }
+        it { is_expected.to contain_package('smartmontools').with_ensure('absent') }
+        it { is_expected.not_to contain_service('smartd') }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('absent') }
       end
 
       describe 'ensure => purge' do
         let(:params) {{ :ensure => 'purged' }}
 
-        it { should contain_package('smartmontools').with_ensure('purged') }
-        it { should_not contain_service('smartd') }
-        it { should contain_file('/etc/smartd.conf').with_ensure('absent') }
+        it { is_expected.to contain_package('smartmontools').with_ensure('purged') }
+        it { is_expected.not_to contain_service('smartd') }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('absent') }
       end
 
       describe 'ensure => badvalue' do
@@ -154,7 +154,7 @@ describe 'smartd', :type => :class do
 
         it 'should fail' do
           expect {
-            should raise_error(Puppet::Error, /unsupported value of $ensure: badvalue/)
+            is_expected.to raise_error(Puppet::Error, /unsupported value of $ensure: badvalue/)
           }
         end
       end
@@ -162,21 +162,21 @@ describe 'smartd', :type => :class do
       describe 'service_ensure => running' do
         let(:params) {{ :service_ensure => 'running' }}
 
-        it { should contain_package('smartmontools').with_ensure('present') }
-        it { should contain_service('smartd').with_ensure('running').with_enable(true) }
+        it { is_expected.to contain_package('smartmontools').with_ensure('present') }
+        it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
       end
 
       describe 'service_ensure => stopped' do
         let(:params) {{ :service_ensure => 'stopped' }}
 
-        it { should contain_package('smartmontools').with_ensure('present') }
-        it { should contain_service('smartd').with_ensure('stopped').with_enable(false) }
+        it { is_expected.to contain_package('smartmontools').with_ensure('present') }
+        it { is_expected.to contain_service('smartd').with_ensure('stopped').with_enable(false) }
       end
 
       describe 'manage_service => false' do
         let(:params) {{ :manage_service => false }}
 
-        it { should_not contain_service('smartd') }
+        it { is_expected.not_to contain_service('smartd') }
       end
 
       describe 'service_ensure => badvalue' do
@@ -184,7 +184,7 @@ describe 'smartd', :type => :class do
 
         it 'should fail' do
           expect {
-            should raise_error(Puppet::Error, /unsupported value of/)
+            is_expected.to raise_error(Puppet::Error, /unsupported value of/)
           }
         end
       end
@@ -192,7 +192,7 @@ describe 'smartd', :type => :class do
       describe 'devicescan =>' do
         context '(default)' do
           it do
-            should contain_file('/etc/smartd.conf').
+            is_expected.to contain_file('/etc/smartd.conf').
               with_ensure('present').
               with_content(/^DEVICESCAN$/)
           end
@@ -202,7 +202,7 @@ describe 'smartd', :type => :class do
           let(:params) {{ :devicescan => true }}
 
           it do
-            should contain_file('/etc/smartd.conf').
+            is_expected.to contain_file('/etc/smartd.conf').
               with_ensure('present').
               with_content(/^DEVICESCAN$/)
           end
@@ -211,7 +211,7 @@ describe 'smartd', :type => :class do
             before { params[:enable_default] = false }
 
             it 'should have the same arguments as DEFAULT would have' do
-              should contain_file('/etc/smartd.conf').
+              is_expected.to contain_file('/etc/smartd.conf').
                 with_ensure('present').
                 with_content(/^DEVICESCAN -m root -M daily$/)
             end
@@ -222,7 +222,7 @@ describe 'smartd', :type => :class do
           let(:params) {{ :devicescan => false }}
 
           it do
-            should contain_file('/etc/smartd.conf').
+            is_expected.to contain_file('/etc/smartd.conf').
               with_ensure('present').
               without_content(/^DEVICESCAN$/)
           end
@@ -232,7 +232,7 @@ describe 'smartd', :type => :class do
           let(:params) {{ :devicescan => 'foo' }}
           it 'should fail' do
             expect {
-              should raise_error(Puppet::Error, /is not a boolean../)
+              is_expected.to raise_error(Puppet::Error, /is not a boolean../)
             }
           end
         end
@@ -241,7 +241,7 @@ describe 'smartd', :type => :class do
       describe 'devicescan_options => somevalue' do
         let(:params) {{ :devicescan_options => 'somevalue' }}
 
-        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
             'DEFAULT -m root -M daily',
@@ -260,7 +260,7 @@ describe 'smartd', :type => :class do
           }
         end
 
-        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
             'DEFAULT -m root -M daily',
@@ -280,7 +280,7 @@ describe 'smartd', :type => :class do
           }
         end
 
-        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
             'DEFAULT -m root -M daily',
@@ -305,7 +305,7 @@ describe 'smartd', :type => :class do
           }
         end
 
-        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
             'DEFAULT -m root -M daily',
@@ -322,7 +322,7 @@ describe 'smartd', :type => :class do
       describe 'mail_to => someguy@localdomain' do
         let(:params) {{ :mail_to => 'someguy@localdomain' }}
 
-        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
             'DEFAULT -m someguy@localdomain -M daily',
@@ -333,7 +333,7 @@ describe 'smartd', :type => :class do
       describe 'warning_schedule => diminishing' do
         let(:params) {{ :warning_schedule => 'diminishing' }}
 
-        it { should contain_file('/etc/smartd.conf').with_ensure('present') }
+        it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
             'DEFAULT -m root -M diminishing',
@@ -346,7 +346,7 @@ describe 'smartd', :type => :class do
 
         it 'should fail' do
           expect {
-            should raise_error(Puppet::Error, /$warning_schedule must be either daily, once, or diminishing./)
+            is_expected.to raise_error(Puppet::Error, /$warning_schedule must be either daily, once, or diminishing./)
           }
         end
       end
@@ -356,7 +356,7 @@ describe 'smartd', :type => :class do
           context 'fact smartmontool_version = "5.43"' do
             before { facts[:smartmontools_version] = '5.43' }
             it do
-              should contain_file('/etc/smartd.conf').with_ensure('present').
+              is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
                 with_content(/DEFAULT -m root -M daily/)
             end
           end
@@ -364,7 +364,7 @@ describe 'smartd', :type => :class do
           context 'fact smartmontool_version = "5.42"' do
             before { facts[:smartmontools_version] = '5.42' }
             it do
-              should contain_file('/etc/smartd.conf').with_ensure('present').
+              is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
                 without_content(/DEFAULT -m root -M daily/).
                 with_content(/DEVICESCAN -m root -M daily/)
             end
@@ -374,7 +374,7 @@ describe 'smartd', :type => :class do
         context 'true' do
           let(:params) {{ :enable_default => true }}
           it do
-            should contain_file('/etc/smartd.conf').with_ensure('present').
+            is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
               with_content(/DEFAULT -m root -M daily/)
           end
         end
@@ -382,7 +382,7 @@ describe 'smartd', :type => :class do
         context 'false' do
           let(:params) {{ :enable_default => false }}
           it do
-            should contain_file('/etc/smartd.conf').with_ensure('present').
+            is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
               without_content(/DEFAULT -m root -M daily/).
               with_content(/DEVICESCAN -m root -M daily/)
           end
@@ -392,7 +392,7 @@ describe 'smartd', :type => :class do
           let(:params) {{ :enable_default => 'foo' }}
           it 'should fail' do
             expect {
-              should raise_error(Puppet::Error, /is not a boolean../)
+              is_expected.to raise_error(Puppet::Error, /is not a boolean../)
             }
           end
         end
@@ -406,7 +406,7 @@ describe 'smartd', :type => :class do
             before { params[:enable_default] = true }
 
             it do
-              should contain_file('/etc/smartd.conf').with_ensure('present').
+              is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
                 with_content(/DEFAULT -m root -M daily/)
             end
           end
@@ -415,7 +415,7 @@ describe 'smartd', :type => :class do
             before { params[:enable_default] = false }
 
             it do
-              should contain_file('/etc/smartd.conf').with_ensure('present').
+              is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
                 without_content(/DEFAULT -m root -M daily/).
                 with_content(/DEVICESCAN -m root -M daily/)
             end
@@ -429,7 +429,7 @@ describe 'smartd', :type => :class do
             before { params[:enable_default] = true }
 
             it do
-              should contain_file('/etc/smartd.conf').with_ensure('present').
+              is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
                 with_content(/DEFAULT -m root -M daily/)
             end
           end
@@ -438,7 +438,7 @@ describe 'smartd', :type => :class do
             before { params[:enable_default] = false }
 
             it do
-              should contain_file('/etc/smartd.conf').with_ensure('present').
+              is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
                 without_content(/DEFAULT -m root -M daily/).
                 with_content(/DEVICESCAN -m root -M daily/)
             end
@@ -452,7 +452,7 @@ describe 'smartd', :type => :class do
             before { params[:enable_default] = true }
 
             it do
-              should contain_file('/etc/smartd.conf').with_ensure('present').
+              is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
                 with_content(/DEFAULT -m root -M daily -H/)
             end
           end
@@ -461,7 +461,7 @@ describe 'smartd', :type => :class do
             before { params[:enable_default] = false }
 
             it do
-              should contain_file('/etc/smartd.conf').with_ensure('present').
+              is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
                 without_content(/DEFAULT -m root -M daily -H/).
                 with_content(/DEVICESCAN -m root -M daily -H/)
             end
@@ -472,7 +472,7 @@ describe 'smartd', :type => :class do
           let(:params) {{ :default_options => [] }}
           it 'should fail' do
             expect {
-              should raise_error(Puppet::Error, /is not an Array../)
+              is_expected.to raise_error(Puppet::Error, /is not an Array../)
             }
           end
         end # []
@@ -485,49 +485,49 @@ describe 'smartd', :type => :class do
       describe 'ensure => present' do
         let(:params) {{ :ensure => 'present' }}
 
-        it { should contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
+        it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       end
 
       describe 'ensure => latest' do
         let(:params) {{ :ensure => 'latest' }}
 
-        it { should contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
+        it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       end
 
       describe 'ensure => absent' do
         let(:params) {{ :ensure => 'absent' }}
 
-        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+        it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
 
       describe 'ensure => purged' do
         let(:params) {{ :ensure => 'purged' }}
 
-        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+        it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
 
       describe 'ensure => absent and service_ensure => running' do
         let(:params) {{ :ensure => 'absent',  :service_ensure => 'running' }}
 
-        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+        it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
 
       describe 'ensure => purged and service_ensure => running' do
         let(:params) {{ :ensure => 'purged',  :service_ensure => 'running' }}
 
-        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+        it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
 
       describe 'service_ensure => running' do
         let(:params) {{ :service_ensure => 'running' }}
 
-        it { should contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
+        it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       end
 
       describe 'service_ensure => stopped' do
         let(:params) {{ :service_ensure => 'stopped' }}
 
-        it { should contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
+        it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
     end
   end
@@ -547,7 +547,7 @@ describe 'smartd', :type => :class do
       end
 
       it do
-        should contain_file('/etc/smartd.conf')\
+        is_expected.to contain_file('/etc/smartd.conf')\
           .with_content(<<-END.gsub(/^\s+/, ""))
             # Managed by Puppet -- do not edit!
             DEFAULT -m root -M daily
@@ -570,7 +570,7 @@ describe 'smartd', :type => :class do
       end
 
       it do
-        should contain_file('/etc/smartd.conf')\
+        is_expected.to contain_file('/etc/smartd.conf')\
           .with_content(<<-END.gsub(/^\s+/, ""))
             # Managed by Puppet -- do not edit!
             DEFAULT -m root -M daily
@@ -594,7 +594,7 @@ describe 'smartd', :type => :class do
       end
 
       it do
-        should contain_file('/etc/smartd.conf')\
+        is_expected.to contain_file('/etc/smartd.conf')\
           .with_content(<<-END.gsub(/^\s+/, ""))
             # Managed by Puppet -- do not edit!
             DEFAULT -m root -M daily
@@ -624,11 +624,11 @@ describe 'smartd', :type => :class do
       end
 
       it do
-        should contain_class('smartd')
-        should contain_class('smartd::params')
-        should contain_package('smartmontools')
-        should contain_service('smartd')
-        should contain_file('/etc/smartd.conf')\
+        is_expected.to contain_class('smartd')
+        is_expected.to contain_class('smartd::params')
+        is_expected.to contain_package('smartmontools')
+        is_expected.to contain_service('smartd')
+        is_expected.to contain_file('/etc/smartd.conf')\
           .with_content(<<-END.gsub(/^\s+/, ""))
             # Managed by Puppet -- do not edit!
             DEFAULT -m root -M daily

--- a/spec/unit/classes/smartd_spec.rb
+++ b/spec/unit/classes/smartd_spec.rb
@@ -1,40 +1,19 @@
 require 'spec_helper'
 
 describe 'smartd', :type => :class do
-
   shared_examples_for 'default' do |values|
-    content = nil
-    if values && values[:content]
-      content = values[:content]
-    else
-      content = [
-        'DEFAULT -m root -M daily',
-        'DEVICESCAN',
-      ]
-    end
-
-    config_file = nil
-    if values && values[:config_file]
-      config_file = values[:config_file]
-    else
-      config_file = '/etc/smartd.conf'
-    end
-
-    group = nil
-    if values && values[:group]
-      group = values[:group]
-    else
-      group = 'root'
-    end
+    content = (values && values[:content]) ? values[:content] : ['DEFAULT -m root -M daily', 'DEVICESCAN']
+    config_file = (values && values[:config_file]) ? values[:config_file] : '/etc/smartd.conf'
+    group = (values && values[:group]) ? values[:group] : 'root'
 
     it { is_expected.to contain_package('smartmontools').with_ensure('present') }
-    it do
-      is_expected.to contain_file(config_file).with({
-        :ensure  => 'present',
-        :owner   => 'root',
-        :group   => group,
-        :mode    => '0644',
-      })
+    it 'should contain the configuration file the parameters set appropriately' do
+      is_expected.to contain_file(config_file).with(
+        :ensure => 'present',
+        :owner  => 'root',
+        :group  => group,
+        :mode   => '0644'
+      )
     end
     it "should contain File[#{config_file}] with correct contents" do
       verify_contents(catalogue, config_file, content)
@@ -43,7 +22,7 @@ describe 'smartd', :type => :class do
 
   describe 'on a supported osfamily, default parameters' do
     describe 'for osfamily SuSE' do
-      let(:facts) {{ :osfamily => 'SuSE', :smartmontools_version => '5.43', :gid => 'root' }}
+      let(:facts) { { :osfamily => 'SuSE', :smartmontools_version => '5.43', :gid => 'root' } }
 
       it_behaves_like 'default', {}
       it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
@@ -54,7 +33,15 @@ describe 'smartd', :type => :class do
     describe 'for osfamily RedHat' do
       describe 'for operatingsystem RedHat' do
         describe 'for operatingsystemmajrelease 6' do
-          let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'RedHat', :operatingsystemmajrelease => '6', :smartmontools_version => '5.43', :gid => 'root' }}
+          let(:facts) do
+            {
+              :osfamily                  => 'RedHat',
+              :operatingsystem           => 'RedHat',
+              :operatingsystemmajrelease => '6',
+              :smartmontools_version     => '5.43',
+              :gid                       => 'root',
+            }
+          end
 
           it_behaves_like 'default', {}
           it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
@@ -63,9 +50,17 @@ describe 'smartd', :type => :class do
         end
 
         describe 'for operatingsystemmajrelease 7' do
-          let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'RedHat', :operatingsystemmajrelease => '7', :smartmontools_version => '6.2', :gid => 'root' }}
+          let(:facts) do
+            {
+              :osfamily                  => 'RedHat',
+              :operatingsystem           => 'RedHat',
+              :operatingsystemmajrelease => '7',
+              :smartmontools_version     => '6.2',
+              :gid                       => 'root',
+            }
+          end
 
-          it_behaves_like 'default', { :config_file => '/etc/smartmontools/smartd.conf' }
+          it_behaves_like 'default', :config_file => '/etc/smartmontools/smartd.conf'
           it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
           it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
           it { is_expected.to contain_service('smartd').with_subscribe('File[/etc/smartmontools/smartd.conf]') }
@@ -74,7 +69,15 @@ describe 'smartd', :type => :class do
 
       describe 'for operatingsystem Fedora' do
         describe 'for operatingsystemrelease 18' do
-          let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '18', :smartmontools_version => '5.43', :gid => 'root' }}
+          let(:facts) do
+            {
+              :osfamily               => 'RedHat',
+              :operatingsystem        => 'Fedora',
+              :operatingsystemrelease => '18',
+              :smartmontools_version  => '5.43',
+              :gid                    => 'root',
+            }
+          end
 
           it_behaves_like 'default', {}
           it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
@@ -83,9 +86,17 @@ describe 'smartd', :type => :class do
         end
 
         describe 'for operatingsystemrelease 19' do
-          let(:facts) {{ :osfamily => 'RedHat', :operatingsystem => 'Fedora', :operatingsystemrelease => '19', :smartmontools_version => '6.1', :gid => 'root' }}
+          let(:facts) do
+            {
+              :osfamily               => 'RedHat',
+              :operatingsystem        => 'Fedora',
+              :operatingsystemrelease => '19',
+              :smartmontools_version  => '6.1',
+              :gid                    => 'root',
+            }
+          end
 
-          it_behaves_like 'default', { :config_file => '/etc/smartmontools/smartd.conf' }
+          it_behaves_like 'default', :config_file => '/etc/smartmontools/smartd.conf'
           it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
           it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
           it { is_expected.to contain_service('smartd').with_subscribe('File[/etc/smartmontools/smartd.conf]') }
@@ -94,7 +105,7 @@ describe 'smartd', :type => :class do
     end
 
     describe 'for osfamily Debian' do
-      let(:facts) {{ :osfamily => 'Debian', :smartmontools_version => '5.43', :gid => 'root' }}
+      let(:facts) { { :osfamily => 'Debian', :smartmontools_version => '5.43', :gid => 'root' } }
 
       it_behaves_like 'default', {}
       it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
@@ -103,22 +114,21 @@ describe 'smartd', :type => :class do
     end
 
     describe 'for osfamily FreeBSD' do
-      let(:facts) {{ :osfamily => 'FreeBSD', :smartmontools_version => '5.43', :gid => 'wheel' }}
+      let(:facts) { { :osfamily => 'FreeBSD', :smartmontools_version => '5.43', :gid => 'wheel' } }
 
-      it_behaves_like 'default', { :config_file => '/usr/local/etc/smartd.conf', :group => 'wheel' }
+      it_behaves_like 'default', :config_file => '/usr/local/etc/smartd.conf', :group => 'wheel'
       it { is_expected.not_to contain_augeas('shell_config_start_smartd') }
       it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
       it { is_expected.to contain_service('smartd').with_subscribe('File[/usr/local/etc/smartd.conf]') }
     end
-
   end
 
   describe 'on a supported osfamily, custom parameters' do
     describe 'for osfamily RedHat' do
-      let(:facts) {{ :osfamily => 'RedHat', :smartmontools_version => '5.43' }}
+      let(:facts) { { :osfamily => 'RedHat', :smartmontools_version => '5.43' } }
 
       describe 'ensure => present' do
-        let(:params) {{ :ensure => 'present' }}
+        let(:params) { { :ensure => 'present' } }
 
         it { is_expected.to contain_package('smartmontools').with_ensure('present') }
         it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
@@ -126,7 +136,7 @@ describe 'smartd', :type => :class do
       end
 
       describe 'ensure => latest' do
-        let(:params) {{ :ensure => 'latest' }}
+        let(:params) { { :ensure => 'latest' } }
 
         it { is_expected.to contain_package('smartmontools').with_ensure('latest') }
         it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
@@ -134,7 +144,7 @@ describe 'smartd', :type => :class do
       end
 
       describe 'ensure => absent' do
-        let(:params) {{ :ensure => 'absent' }}
+        let(:params) { { :ensure => 'absent' } }
 
         it { is_expected.to contain_package('smartmontools').with_ensure('absent') }
         it { is_expected.not_to contain_service('smartd') }
@@ -142,7 +152,7 @@ describe 'smartd', :type => :class do
       end
 
       describe 'ensure => purge' do
-        let(:params) {{ :ensure => 'purged' }}
+        let(:params) { { :ensure => 'purged' } }
 
         it { is_expected.to contain_package('smartmontools').with_ensure('purged') }
         it { is_expected.not_to contain_service('smartd') }
@@ -150,42 +160,42 @@ describe 'smartd', :type => :class do
       end
 
       describe 'ensure => badvalue' do
-        let(:params) {{ :ensure => 'badvalue' }}
+        let(:params) { { :ensure => 'badvalue' } }
 
         it 'should fail' do
-          expect {
+          expect do
             is_expected.to raise_error(Puppet::Error, /unsupported value of $ensure: badvalue/)
-          }
+          end
         end
       end
 
       describe 'service_ensure => running' do
-        let(:params) {{ :service_ensure => 'running' }}
+        let(:params) { { :service_ensure => 'running' } }
 
         it { is_expected.to contain_package('smartmontools').with_ensure('present') }
         it { is_expected.to contain_service('smartd').with_ensure('running').with_enable(true) }
       end
 
       describe 'service_ensure => stopped' do
-        let(:params) {{ :service_ensure => 'stopped' }}
+        let(:params) { { :service_ensure => 'stopped' } }
 
         it { is_expected.to contain_package('smartmontools').with_ensure('present') }
         it { is_expected.to contain_service('smartd').with_ensure('stopped').with_enable(false) }
       end
 
       describe 'manage_service => false' do
-        let(:params) {{ :manage_service => false }}
+        let(:params) { { :manage_service => false } }
 
         it { is_expected.not_to contain_service('smartd') }
       end
 
       describe 'service_ensure => badvalue' do
-        let(:params) {{ :service_ensure => 'badvalue' }}
+        let(:params) { { :service_ensure => 'badvalue' } }
 
         it 'should fail' do
-          expect {
+          expect do
             is_expected.to raise_error(Puppet::Error, /unsupported value of/)
-          }
+          end
         end
       end
 
@@ -199,7 +209,7 @@ describe 'smartd', :type => :class do
         end # (default)
 
         context 'true' do
-          let(:params) {{ :devicescan => true }}
+          let(:params) { { :devicescan => true } }
 
           it do
             is_expected.to contain_file('/etc/smartd.conf').
@@ -219,7 +229,7 @@ describe 'smartd', :type => :class do
         end # true
 
         context 'false' do
-          let(:params) {{ :devicescan => false }}
+          let(:params) { { :devicescan => false } }
 
           it do
             is_expected.to contain_file('/etc/smartd.conf').
@@ -229,24 +239,24 @@ describe 'smartd', :type => :class do
         end # false
 
         context 'foo' do
-          let(:params) {{ :devicescan => 'foo' }}
+          let(:params) { { :devicescan => 'foo' } }
           it 'should fail' do
-            expect {
+            expect do
               is_expected.to raise_error(Puppet::Error, /is not a boolean../)
-            }
+            end
           end
         end
       end # devicescan =>
 
       describe 'devicescan_options => somevalue' do
-        let(:params) {{ :devicescan_options => 'somevalue' }}
+        let(:params) { { :devicescan_options => 'somevalue' } }
 
         it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
-            'DEFAULT -m root -M daily',
-            'DEVICESCAN somevalue',
-          ])
+                            'DEFAULT -m root -M daily',
+                            'DEVICESCAN somevalue',
+                          ])
         end
       end
 
@@ -263,10 +273,10 @@ describe 'smartd', :type => :class do
         it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
-            'DEFAULT -m root -M daily',
-            '/dev/sg1',
-            '/dev/sg2',
-          ])
+                            'DEFAULT -m root -M daily',
+                            '/dev/sg1',
+                            '/dev/sg2',
+                          ])
         end
       end
 
@@ -283,10 +293,10 @@ describe 'smartd', :type => :class do
         it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
-            'DEFAULT -m root -M daily',
-            '/dev/sg1 -o on -S on -a',
-            '/dev/sg2 -o on -S on -a',
-          ])
+                            'DEFAULT -m root -M daily',
+                            '/dev/sg1 -o on -S on -a',
+                            '/dev/sg2 -o on -S on -a',
+                          ])
         end
       end
 
@@ -308,46 +318,46 @@ describe 'smartd', :type => :class do
         it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
-            'DEFAULT -m root -M daily',
-            '/dev/cciss/c0d0 -d cciss,0 -a -o on -S on',
-            '/dev/cciss/c0d0 -d cciss,1 -a -o on -S on',
-            '/dev/cciss/c0d0 -d cciss,2 -a -o on -S on',
-            '/dev/cciss/c0d0 -d cciss,3 -a -o on -S on',
-            '/dev/cciss/c0d0 -d cciss,4 -a -o on -S on',
-            '/dev/cciss/c0d0 -d cciss,5 -a -o on -S on',
-          ])
+                            'DEFAULT -m root -M daily',
+                            '/dev/cciss/c0d0 -d cciss,0 -a -o on -S on',
+                            '/dev/cciss/c0d0 -d cciss,1 -a -o on -S on',
+                            '/dev/cciss/c0d0 -d cciss,2 -a -o on -S on',
+                            '/dev/cciss/c0d0 -d cciss,3 -a -o on -S on',
+                            '/dev/cciss/c0d0 -d cciss,4 -a -o on -S on',
+                            '/dev/cciss/c0d0 -d cciss,5 -a -o on -S on',
+                          ])
         end
       end
 
       describe 'mail_to => someguy@localdomain' do
-        let(:params) {{ :mail_to => 'someguy@localdomain' }}
+        let(:params) { { :mail_to => 'someguy@localdomain' } }
 
         it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
-            'DEFAULT -m someguy@localdomain -M daily',
-          ])
+                            'DEFAULT -m someguy@localdomain -M daily',
+                          ])
         end
       end
 
       describe 'warning_schedule => diminishing' do
-        let(:params) {{ :warning_schedule => 'diminishing' }}
+        let(:params) { { :warning_schedule => 'diminishing' } }
 
         it { is_expected.to contain_file('/etc/smartd.conf').with_ensure('present') }
         it 'should contain file /etc/smartd.conf with contents ...' do
           verify_contents(catalogue, '/etc/smartd.conf', [
-            'DEFAULT -m root -M diminishing',
-          ])
+                            'DEFAULT -m root -M diminishing',
+                          ])
         end
       end
 
       describe 'warning_schedule => badvalue' do
-        let(:params) {{ :warning_schedule => 'badvalue' }}
+        let(:params) { { :warning_schedule => 'badvalue' } }
 
         it 'should fail' do
-          expect {
+          expect do
             is_expected.to raise_error(Puppet::Error, /$warning_schedule must be either daily, once, or diminishing./)
-          }
+          end
         end
       end
 
@@ -372,7 +382,7 @@ describe 'smartd', :type => :class do
         end # (default)
 
         context 'true' do
-          let(:params) {{ :enable_default => true }}
+          let(:params) { { :enable_default => true } }
           it do
             is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
               with_content(/DEFAULT -m root -M daily/)
@@ -380,7 +390,7 @@ describe 'smartd', :type => :class do
         end
 
         context 'false' do
-          let(:params) {{ :enable_default => false }}
+          let(:params) { { :enable_default => false } }
           it do
             is_expected.to contain_file('/etc/smartd.conf').with_ensure('present').
               without_content(/DEFAULT -m root -M daily/).
@@ -389,18 +399,18 @@ describe 'smartd', :type => :class do
         end
 
         context 'foo' do
-          let(:params) {{ :enable_default => 'foo' }}
+          let(:params) { { :enable_default => 'foo' } }
           it 'should fail' do
-            expect {
+            expect do
               is_expected.to raise_error(Puppet::Error, /is not a boolean../)
-            }
+            end
           end
         end
       end # enable_default =>
 
       describe 'default_options => ' do
         context '(default)' do
-          let(:params) {{ }}
+          let(:params) { {} }
 
           context 'default => true' do
             before { params[:enable_default] = true }
@@ -423,7 +433,7 @@ describe 'smartd', :type => :class do
         end # (default)
 
         context 'undef' do
-          let(:params) {{ :default_options => nil }}
+          let(:params) { { :default_options => nil } }
 
           context 'enable_default => true' do
             before { params[:enable_default] = true }
@@ -446,7 +456,7 @@ describe 'smartd', :type => :class do
         end # undef
 
         context '-H' do
-          let(:params) {{ :default_options => '-H'}}
+          let(:params) { { :default_options => '-H' } }
 
           context 'enable_default => true' do
             before { params[:enable_default] = true }
@@ -469,72 +479,70 @@ describe 'smartd', :type => :class do
         end # -H
 
         context '[]' do
-          let(:params) {{ :default_options => [] }}
+          let(:params) { { :default_options => [] } }
           it 'should fail' do
-            expect {
+            expect do
               is_expected.to raise_error(Puppet::Error, /is not an Array../)
-            }
+            end
           end
         end # []
       end # default_options =>
     end
 
     describe 'for osfamily Debian' do
-      let(:facts) {{ :osfamily => 'Debian', :smartmontools_version => '5.43' }}
+      let(:facts) { { :osfamily => 'Debian', :smartmontools_version => '5.43' } }
 
       describe 'ensure => present' do
-        let(:params) {{ :ensure => 'present' }}
+        let(:params) { { :ensure => 'present' } }
 
         it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       end
 
       describe 'ensure => latest' do
-        let(:params) {{ :ensure => 'latest' }}
+        let(:params) { { :ensure => 'latest' } }
 
         it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       end
 
       describe 'ensure => absent' do
-        let(:params) {{ :ensure => 'absent' }}
+        let(:params) { { :ensure => 'absent' } }
 
         it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
 
       describe 'ensure => purged' do
-        let(:params) {{ :ensure => 'purged' }}
+        let(:params) { { :ensure => 'purged' } }
 
         it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
 
       describe 'ensure => absent and service_ensure => running' do
-        let(:params) {{ :ensure => 'absent',  :service_ensure => 'running' }}
+        let(:params) { { :ensure => 'absent', :service_ensure => 'running' } }
 
         it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
 
       describe 'ensure => purged and service_ensure => running' do
-        let(:params) {{ :ensure => 'purged',  :service_ensure => 'running' }}
+        let(:params) { { :ensure => 'purged', :service_ensure => 'running' } }
 
         it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
 
       describe 'service_ensure => running' do
-        let(:params) {{ :service_ensure => 'running' }}
+        let(:params) { { :service_ensure => 'running' } }
 
         it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('set start_smartd "yes"') }
       end
 
       describe 'service_ensure => stopped' do
-        let(:params) {{ :service_ensure => 'stopped' }}
+        let(:params) { { :service_ensure => 'stopped' } }
 
         it { is_expected.to contain_augeas('shell_config_start_smartd').with_changes('remove start_smartd') }
       end
     end
   end
 
-
   describe 'megaraid support' do
-
     describe 'without params + megaraid sata facts' do
       let(:facts) do
         {
@@ -547,8 +555,8 @@ describe 'smartd', :type => :class do
       end
 
       it do
-        is_expected.to contain_file('/etc/smartd.conf')\
-          .with_content(<<-END.gsub(/^\s+/, ""))
+        is_expected.to contain_file('/etc/smartd.conf').\
+          with_content(<<-END.gsub(/^\s+/, ''))
             # Managed by Puppet -- do not edit!
             DEFAULT -m root -M daily
             /dev/sda -d sat+megaraid,1
@@ -570,8 +578,8 @@ describe 'smartd', :type => :class do
       end
 
       it do
-        is_expected.to contain_file('/etc/smartd.conf')\
-          .with_content(<<-END.gsub(/^\s+/, ""))
+        is_expected.to contain_file('/etc/smartd.conf').\
+          with_content(<<-END.gsub(/^\s+/, ''))
             # Managed by Puppet -- do not edit!
             DEFAULT -m root -M daily
             /dev/sda -d megaraid,1
@@ -594,8 +602,8 @@ describe 'smartd', :type => :class do
       end
 
       it do
-        is_expected.to contain_file('/etc/smartd.conf')\
-          .with_content(<<-END.gsub(/^\s+/, ""))
+        is_expected.to contain_file('/etc/smartd.conf').\
+          with_content(<<-END.gsub(/^\s+/, ''))
             # Managed by Puppet -- do not edit!
             DEFAULT -m root -M daily
             /dev/sda -d sat+megaraid,3
@@ -628,8 +636,8 @@ describe 'smartd', :type => :class do
         is_expected.to contain_class('smartd::params')
         is_expected.to contain_package('smartmontools')
         is_expected.to contain_service('smartd')
-        is_expected.to contain_file('/etc/smartd.conf')\
-          .with_content(<<-END.gsub(/^\s+/, ""))
+        is_expected.to contain_file('/etc/smartd.conf').\
+          with_content(<<-END.gsub(/^\s+/, ''))
             # Managed by Puppet -- do not edit!
             DEFAULT -m root -M daily
             /dev/sda -d sat+megaraid,1 -I 194

--- a/spec/unit/facts/megacli_spec.rb
+++ b/spec/unit/facts/megacli_spec.rb
@@ -30,6 +30,4 @@ describe 'megacli', :type => :fact do
       end
     end
   end
-
 end
-

--- a/spec/unit/facts/megacli_version_spec.rb
+++ b/spec/unit/facts/megacli_version_spec.rb
@@ -37,6 +37,4 @@ describe 'megacli_version', :type => :fact do
       expect(Facter.fact(:megacli_version).value).to eq('8.00.11')
     end
   end
-
 end
-

--- a/spec/unit/facts/megaraid_adapters_spec.rb
+++ b/spec/unit/facts/megaraid_adapters_spec.rb
@@ -20,7 +20,7 @@ describe 'megaraid_adapters', :type => :fact do
         Facter::Util::Resolution.stubs(:exec).with('/usr/bin/MegaCli -adpCount -NoLog 2>&1').
           returns(nil)
 
-        expect(Facter.fact(:megaraid_adapters).value).to  eq('0')
+        expect(Facter.fact(:megaraid_adapters).value).to eq('0')
       end
     end
 
@@ -31,7 +31,7 @@ describe 'megaraid_adapters', :type => :fact do
         Facter::Util::Resolution.stubs(:exec).with('/usr/bin/MegaCli -adpCount -NoLog 2>&1').
           returns(File.read(fixtures('megacli', 'adpcount-count_0')))
 
-        expect(Facter.fact(:megaraid_adapters).value).to  eq('0')
+        expect(Facter.fact(:megaraid_adapters).value).to eq('0')
       end
 
       it 'should find 1 adapters' do
@@ -40,7 +40,7 @@ describe 'megaraid_adapters', :type => :fact do
         Facter::Util::Resolution.stubs(:exec).with('/usr/bin/MegaCli -adpCount -NoLog 2>&1').
           returns(File.read(fixtures('megacli', 'adpcount-count_1')))
 
-        expect(Facter.fact(:megaraid_adapters).value).to  eq('1')
+        expect(Facter.fact(:megaraid_adapters).value).to eq('1')
       end
     end
   end # on linux
@@ -52,5 +52,4 @@ describe 'megaraid_adapters', :type => :fact do
       expect(Facter.fact(:megaraid_adapters).value).to be_nil
     end
   end # not on linux
-
 end

--- a/spec/unit/facts/megaraid_fw_package_build_spec.rb
+++ b/spec/unit/facts/megaraid_fw_package_build_spec.rb
@@ -40,5 +40,4 @@ describe 'megaraid_fw_package_build', :type => :fact do
       end
     end
   end
-
 end

--- a/spec/unit/facts/megaraid_fw_version_spec.rb
+++ b/spec/unit/facts/megaraid_fw_version_spec.rb
@@ -40,5 +40,4 @@ describe 'megaraid_fw_version', :type => :fact do
       end
     end
   end
-
 end

--- a/spec/unit/facts/megaraid_physical_drives_sas_spec.rb
+++ b/spec/unit/facts/megaraid_physical_drives_sas_spec.rb
@@ -44,6 +44,7 @@ describe 'megaraid_physical_drives_sas', :type => :fact do
     end
 
     context '1 adapter' do
+      let(:drives_list) { '188,189,190,192,194,197,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214' }
       it do
         Facter.fact(:kernel).stubs(:value).returns('Linux')
         Facter.fact(:megacli).stubs(:value).returns('/usr/bin/MegaCli')
@@ -51,7 +52,7 @@ describe 'megaraid_physical_drives_sas', :type => :fact do
         Facter::Util::Resolution.stubs(:exec).with('/usr/bin/MegaCli -PDList -aALL -NoLog').
           returns(File.read(fixtures('megacli', 'pdlistaall')))
 
-        expect(Facter.fact(:megaraid_physical_drives_sas).value).to eq('188,189,190,192,194,197,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214')
+        expect(Facter.fact(:megaraid_physical_drives_sas).value).to eq(drives_list)
       end
     end
   end # on linux

--- a/spec/unit/facts/megaraid_physical_drives_sata_spec.rb
+++ b/spec/unit/facts/megaraid_physical_drives_sata_spec.rb
@@ -44,6 +44,10 @@ describe 'megaraid_physical_drives_sata', :type => :fact do
     end
 
     context '1 adapter' do
+      let(:drives_list) do
+        '10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,' \
+        '32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,184,185'
+      end
       it do
         Facter.fact(:kernel).stubs(:value).returns('Linux')
         Facter.fact(:megacli).stubs(:value).returns('/usr/bin/MegaCli')
@@ -51,7 +55,7 @@ describe 'megaraid_physical_drives_sata', :type => :fact do
         Facter::Util::Resolution.stubs(:exec).with('/usr/bin/MegaCli -PDList -aALL -NoLog').
           returns(File.read(fixtures('megacli', 'pdlistaall')))
 
-        expect(Facter.fact(:megaraid_physical_drives_sata).value).to eq('10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,184,185')
+        expect(Facter.fact(:megaraid_physical_drives_sata).value).to eq(drives_list)
       end
     end
   end # on linux

--- a/spec/unit/facts/megaraid_physical_drives_size_spec.rb
+++ b/spec/unit/facts/megaraid_physical_drives_size_spec.rb
@@ -44,24 +44,25 @@ describe 'megaraid_physical_drives_size', :type => :fact do
     end
 
     context '1 adapter' do
+      let(:sizes) do
+        '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,'     \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,'   \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,'   \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,'   \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,'   \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,'   \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,186.310 GB,' \
+          '186.310 GB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,'   \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,'   \
+          '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB'
+      end
       it do
         Facter.fact(:kernel).stubs(:value).returns('Linux')
         Facter.fact(:megacli).stubs(:value).returns('/usr/bin/MegaCli')
         Facter.fact(:megaraid_adapters).stubs(:value).returns('1')
         Facter::Util::Resolution.stubs(:exec).with('/usr/bin/MegaCli -PDList -aALL -NoLog').
           returns(File.read(fixtures('megacli', 'pdlistaall')))
-
-        sizes = '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,186.310 GB,' +
-                '186.310 GB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,' +
-                '3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB,3.638 TB'
         expect(Facter.fact(:megaraid_physical_drives_size).value).to eq(sizes)
       end
     end

--- a/spec/unit/facts/megaraid_physical_drives_spec.rb
+++ b/spec/unit/facts/megaraid_physical_drives_spec.rb
@@ -44,6 +44,12 @@ describe 'megaraid_physical_drives', :type => :fact do
     end
 
     context '1 adapter' do
+      let(:drives_list) do
+        '10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,' \
+          '32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,184,' \
+          '185,188,189,190,192,194,197,199,200,201,202,203,204,205,206,207,' \
+          '208,209,210,211,212,213,214'
+      end
       it do
         Facter.fact(:kernel).stubs(:value).returns('Linux')
         Facter.fact(:megacli).stubs(:value).returns('/usr/bin/MegaCli')
@@ -51,7 +57,7 @@ describe 'megaraid_physical_drives', :type => :fact do
         Facter::Util::Resolution.stubs(:exec).with('/usr/bin/MegaCli -PDList -aALL -NoLog').
           returns(File.read(fixtures('megacli', 'pdlistaall')))
 
-        expect(Facter.fact(:megaraid_physical_drives).value).to eq('10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,184,185,188,189,190,192,194,197,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214')
+        expect(Facter.fact(:megaraid_physical_drives).value).to eq(drives_list)
       end
     end
   end # on linux

--- a/spec/unit/facts/megaraid_product_name_spec.rb
+++ b/spec/unit/facts/megaraid_product_name_spec.rb
@@ -40,5 +40,4 @@ describe 'megaraid_product_name', :type => :fact do
       end
     end
   end
-
 end

--- a/spec/unit/facts/megaraid_serial_spec.rb
+++ b/spec/unit/facts/megaraid_serial_spec.rb
@@ -61,7 +61,5 @@ describe 'megaraid_serial', :type => :fact do
         end
       end
     end
-
   end
-
 end

--- a/spec/unit/facts/megaraid_virtual_drives_spec.rb
+++ b/spec/unit/facts/megaraid_virtual_drives_spec.rb
@@ -21,7 +21,6 @@ describe 'megaraid_virtual_drives', :type => :fact do
 
         expect(Facter.fact(:megaraid_virtual_drives).value).to be_nil
       end
-
     end
 
     context 'no adapters' do
@@ -71,7 +70,7 @@ describe 'megaraid_virtual_drives', :type => :fact do
         }
 
         # stolen from rspec-puppet
-        facts.each { |k, v| Facter.add(k) { setcode { v } }  }
+        facts.each { |k, v| Facter.add(k) { setcode { v } } }
       end
 
       it do

--- a/spec/unit/facts/smartmontools_version_spec.rb
+++ b/spec/unit/facts/smartmontools_version_spec.rb
@@ -34,5 +34,4 @@ describe 'smartmontools_version', :type => :fact do
       expect(Facter.fact(:smartmontools_version).value).to eq('5.43')
     end
   end
-
 end


### PR DESCRIPTION
I was going to add some new functionality, but the spec tests were a little hard to follow and a lot of the platform-dependent tests only included contexts for RedHat.  I ended up doing a pretty massive overhaul and this is the result.  Most of the work is in aeb57a5, the other commits are just in support of it.  The coverage should be just as good, if not better than it was before.  It also includes some changes for RuboCop.  Let me know if you want anything changed.
