### PR TITLE
enable option "exec" to -M

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,17 @@ Smart daemon notification email address.
 `String` defaults to: `daily`
 
 Smart daemon problem mail notification frequency. Valid values are:
-`daily`,`once`,`diminishing`
+`daily`,`once`,`diminishing`, `exec`
+
+If `exec` is selected, a value must be provided to `exec_script`.
+
+#### `exec_script`
+
+`String` defaults to: `false`
+
+Path to the script that should be executed when problem mail notification
+should be sent. This parameter should only be set if `warning_schedule` is set
+to `exec`.
 
 #### `enable_default`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,10 +89,19 @@
 #   `String`
 #
 #   Smart daemon problem mail notification frequency. Valid values are:
-#   `daily`,`once`,`diminishing`
+#   `daily`,`once`,`diminishing`, `exec`
+#
+#   Note that if the value `exec` is used, then the parameter `exec_script`
+#   *must* be specified.
 #
 #   defaults to: `daily`
 #
+# [*exec_script*]
+#   `String`
+#
+#   Script that should be executed if warning_schedule is set to `exec`.
+#
+#   defaults to: `undef`
 #
 # === Authors
 #
@@ -116,6 +125,7 @@ class smartd (
   $devices            = $smartd::params::devices,
   $mail_to            = $smartd::params::mail_to,
   $warning_schedule   = $smartd::params::warning_schedule,
+  $exec_script        = $smartd::params::exec_script,
   $enable_default     = $smartd::params::enable_default,
   $default_options    = $smartd::params::default_options,
 ) inherits smartd::params {
@@ -128,8 +138,20 @@ class smartd (
   validate_string($devicescan_options)
   validate_array($devices)
   validate_string($mail_to)
-  validate_re($warning_schedule, '^daily$|^once$|^diminishing$',
-    '$warning_schedule must be either daily, once, or diminishing.')
+  validate_re($warning_schedule, '^daily$|^once$|^diminishing$|^exec$',
+    '$warning_schedule must be either daily, once, diminishing, or exec.')
+  if $warning_schedule == 'exec' {
+    if $exec_script == false {
+      fail('$exec_script must be set when $warning_schedule is set to exec.')
+    }
+    $real_warning_schedule = "${warning_schedule} ${exec_script}"
+  }
+  else {
+    if $exec_script != false {
+      fail('$exec_script should not be used when $warning_schedule is not set to exec.')
+    }
+    $real_warning_schedule = $warning_schedule
+  }
   validate_bool($enable_default)
   validate_string($default_options)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,8 @@ class smartd::params {
   $devicescan_options = undef
   $devices            = []
   $mail_to            = 'root'
-  $warning_schedule   = 'daily' # other choices: once, diminishing
+  $warning_schedule   = 'daily' # other choices: once, diminishing, exec
+  $exec_script        = false
   $default_options    = undef
 
   $version_string = $::smartmontools_version ? {

--- a/templates/smartd.conf
+++ b/templates/smartd.conf
@@ -1,6 +1,6 @@
 # Managed by Puppet -- do not edit!
 <% if @enable_default -%>
-DEFAULT -m <%= @mail_to %> -M <%= @warning_schedule %><% if @default_options %><%= ' ' + @default_options %><% end %>
+DEFAULT -m <%= @mail_to %> -M <%= @real_warning_schedule %><% if @default_options %><%= ' ' + @default_options %><% end %>
 <% end -%>
 <% @devices.each do |dev| -%>
 <%  next if dev['device'] == 'megaraid' -%>
@@ -35,7 +35,7 @@ megaraid_options = nil
 <% end -%>
 <% if @devicescan -%>
 <% unless @enable_default -%>
-DEVICESCAN -m <%= @mail_to %> -M <%= @warning_schedule %><% if @default_options %><%= ' ' + @default_options %><% end %><% if @devicescan_options %><%= ' ' + @devicescan_options %><% end %>
+DEVICESCAN -m <%= @mail_to %> -M <%= @real_warning_schedule %><% if @default_options %><%= ' ' + @default_options %><% end %><% if @devicescan_options %><%= ' ' + @devicescan_options %><% end %>
 <% else -%>
 DEVICESCAN<% if @devicescan_options %><%= ' ' + @devicescan_options %><% end %>
 <% end -%>


### PR DESCRIPTION
some distributions default to using -M exec with a script that calls
different actions (scripts) that can be dropped into a .d directory.
This notification mode is currently impossible to set.

This would close #54 

I haven't written any tests yet. I'd like to know first if the change's style is OK with you.